### PR TITLE
Split lint and code formatting check in GitHub Actions workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,3 +1,4 @@
+name: Code checks workflow
 on:
   push:
     branches: [ 'main' ]
@@ -9,8 +10,8 @@ on:
       - '*.yaml'
       - assets/**
       - .fvm/fvm_config.json
-
-name: Code checks workflow
+      - .tool-versions
+      - .github/workflows/code-quality.yml
 
 concurrency:
   group: qa-${{ github.ref }}
@@ -61,11 +62,65 @@ jobs:
           dart analyze --fatal-infos --fatal-warnings \
             ${{ needs.check-changes.outputs.changed_files }}
 
+  check-format:
+    name: Check code formatting on affected files
+    runs-on: ubuntu-latest
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.changed_dart_files }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - id: versions
+        name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2.19.0
+        with:
+          channel: stable
+          flutter-version: ${{ steps.versions.outputs.flutter }}
+
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-cache-
+
+      - name: Setup Firebase Options
+        run: |
+          tee lib/firebase_options.dart <<EOF
+          class DefaultFirebaseOptions {
+            static const currentPlatform = null;
+          }
+          EOF
+
+      - name: Get files to check
+        id: files-to-check
+        run: |
+          changed_dart_files="${{ needs.check-changes.outputs.changed_dart_files }}"
+
+          # if no dart files changed, get all dart files in the repository
+          if [ "$changed_dart_files" == '.' ]; then
+              changed_dart_files=$(find . -type f -name '*.dart' -not -path '*/.dart_tool/*' | xargs)
+          fi
+
+          # get excluded files from analysis_options.yaml
+          excluded_files=$(yq eval '.analyzer.exclude | .[]' analysis_options.yaml | xargs)
+
+          # filter $changed_dart_files to exclude $excluded_files
+          changed_dart_files=$(echo "$changed_dart_files" | tr ' ' '\n' \
+            | grep -vE "$(echo "$excluded_files" | sed 's/ /|/g' | sed 's/\*/.*/g' | sed 's#/#/#g')" \
+            | tr '\n' ' ' | xargs)
+
+          echo "value=$changed_dart_files" >> $GITHUB_OUTPUT
+
       - name: Check code formatting
-        if: ${{ always() && needs.check-changes.outputs.changed_dart_files }}
         run: |
           dart format --output=none --set-exit-if-changed \
-            ${{ needs.check-changes.outputs.changed_dart_files }}
+            ${{ steps.files-to-check.outputs.value }}
 
   unit-tests:
     name: Run unit tests

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,7 @@
 include: package:flutter_lints/flutter.yaml
 
 formatter:
-  page_width: 120
+  page_width: 80
 
 analyzer:
   strong-mode:

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -17,7 +17,9 @@ class App extends StatefulWidget {
 
 class _AppState extends State<App> with WidgetsBindingObserver {
   late final IAnalytics analytics = get();
-  late final AnalyticsRouteObserver observer = AnalyticsRouteObserver(analytics: analytics);
+  late final AnalyticsRouteObserver observer = AnalyticsRouteObserver(
+    analytics: analytics,
+  );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/common/advertising/ad_list_view_separator.dart
+++ b/lib/common/advertising/ad_list_view_separator.dart
@@ -13,15 +13,23 @@ const _nativeAdMinHeight = 90.0;
 const _nativeAdMaxHeight = 90.0;
 
 class AdListViewSeparatorBuilder {
-  AdListViewSeparatorBuilder({this.everyNthItem = 4, this.unitId = '', this.defaultDivider = const ListDivider()});
+  AdListViewSeparatorBuilder({
+    this.everyNthItem = 4,
+    this.unitId = '',
+    this.defaultDivider = const ListDivider(),
+  });
 
   final int everyNthItem;
   final String unitId;
   final Widget defaultDivider;
 
   Widget call(BuildContext context, int index) {
-    if (unitId.isNotEmpty && everyNthItem > 1 && index % everyNthItem == everyNthItem - 1) {
-      return _NativeAdListSeparatorFrame(child: _NativeAdListSeparator(key: UniqueKey(), adUnitId: unitId));
+    if (unitId.isNotEmpty &&
+        everyNthItem > 1 &&
+        index % everyNthItem == everyNthItem - 1) {
+      return _NativeAdListSeparatorFrame(
+        child: _NativeAdListSeparator(key: UniqueKey(), adUnitId: unitId),
+      );
     }
     return defaultDivider;
   }
@@ -84,7 +92,9 @@ class _NativeAdListSeparatorState extends State<_NativeAdListSeparator> {
         },
       ),
       request: const AdRequest(),
-      nativeTemplateStyle: NativeTemplateStyle(templateType: TemplateType.small),
+      nativeTemplateStyle: NativeTemplateStyle(
+        templateType: TemplateType.small,
+      ),
     );
 
     try {
@@ -93,7 +103,8 @@ class _NativeAdListSeparatorState extends State<_NativeAdListSeparator> {
     } catch (error, stack) {
       if (kDebugMode &&
           error is PlatformException &&
-          error.message?.startsWith('Ad for following adId already exists: ') == true) {
+          error.message?.startsWith('Ad for following adId already exists: ') ==
+              true) {
         // workaround for the issue with the hot reload: https://github.com/googleads/googleads-mobile-flutter/issues/78
         await Future.delayed(const Duration(seconds: 1));
         return loadAd();
@@ -133,7 +144,10 @@ class _NativeAdListSeparatorState extends State<_NativeAdListSeparator> {
 
     if (!_nativeAdIsLoaded || nativeAd == null) {
       return Center(
-        child: Text(context.strings.advertisementPlaceholder, style: Theme.of(context).textTheme.bodyMedium),
+        child: Text(
+          context.strings.advertisementPlaceholder,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
       );
     }
 

--- a/lib/common/common_module.dart
+++ b/lib/common/common_module.dart
@@ -30,16 +30,24 @@ void commonModule() {
 
   registerSingleton(() => PhoneNumberUtil());
 
-  registerSingletonAsync<Database>(getDatabase, dispose: (db) async => db.close());
-
-  registerSingletonAsync<BriteDatabase>(
-    () async => BriteDatabase(await lazyGet(), logger: kDebugMode ? print : null),
+  registerSingletonAsync<Database>(
+    getDatabase,
     dispose: (db) async => db.close(),
   );
 
-  registerSingletonAsync<SharedPreferences>(() async => SharedPreferences.getInstance());
+  registerSingletonAsync<BriteDatabase>(
+    () async =>
+        BriteDatabase(await lazyGet(), logger: kDebugMode ? print : null),
+    dispose: (db) async => db.close(),
+  );
 
-  registerSingletonAsync<FirebaseRemoteConfig>(() async => getRemoteConfig(remoteConfigDefaults));
+  registerSingletonAsync<SharedPreferences>(
+    () async => SharedPreferences.getInstance(),
+  );
+
+  registerSingletonAsync<FirebaseRemoteConfig>(
+    () async => getRemoteConfig(remoteConfigDefaults),
+  );
 
   registerSingleton<IRemoteConfigStorage>(
     () => FirebaseConfigStorage(remoteConfig: get()),
@@ -47,7 +55,10 @@ void commonModule() {
   );
 
   registerSingleton<ILocalConfigStorage>(
-    () => PreferencesConfigStorage(prefs: get(), localConfigDefaults: localConfigDefaults),
+    () => PreferencesConfigStorage(
+      prefs: get(),
+      localConfigDefaults: localConfigDefaults,
+    ),
     dependsOn: [SharedPreferences],
   );
 

--- a/lib/common/config/env_config.dart
+++ b/lib/common/config/env_config.dart
@@ -1,12 +1,24 @@
 import 'dart:io';
 
-const _homeAdListAndroidUnitId = String.fromEnvironment('ZAPIFY_HOME_AD_LIST_ANDROID_UNIT_ID', defaultValue: '');
-const _homeAdListIosUnitId = String.fromEnvironment('ZAPIFY_HOME_AD_LIST_IOS_UNIT_ID', defaultValue: '');
+const _homeAdListAndroidUnitId = String.fromEnvironment(
+  'ZAPIFY_HOME_AD_LIST_ANDROID_UNIT_ID',
+  defaultValue: '',
+);
+const _homeAdListIosUnitId = String.fromEnvironment(
+  'ZAPIFY_HOME_AD_LIST_IOS_UNIT_ID',
+  defaultValue: '',
+);
 
 class EnvConfig {
-  static const amplitudeKey = String.fromEnvironment('ZAPIFY_AMPLITUDE_KEY', defaultValue: '');
+  static const amplitudeKey = String.fromEnvironment(
+    'ZAPIFY_AMPLITUDE_KEY',
+    defaultValue: '',
+  );
 
-  static const homeBannerUnitId = String.fromEnvironment('ZAPIFY_HOME_BANNER_UNIT_ID', defaultValue: '');
+  static const homeBannerUnitId = String.fromEnvironment(
+    'ZAPIFY_HOME_BANNER_UNIT_ID',
+    defaultValue: '',
+  );
 
   static String get homeAdListUnitId {
     if (Platform.isAndroid) return _homeAdListAndroidUnitId;
@@ -14,5 +26,8 @@ class EnvConfig {
     return '';
   }
 
-  static const appStoreId = String.fromEnvironment('ZAPIFY_APP_STORE_ID', defaultValue: '');
+  static const appStoreId = String.fromEnvironment(
+    'ZAPIFY_APP_STORE_ID',
+    defaultValue: '',
+  );
 }

--- a/lib/common/config/local_config.dart
+++ b/lib/common/config/local_config.dart
@@ -4,7 +4,10 @@ import '../di/inject.dart' as di;
 
 const _appId = 'com.zapfy.app';
 
-enum LocalConfig with KeyValueMixin<ILocalConfigStorage>, KeyValueWritableMixin<ILocalConfigStorage> {
+enum LocalConfig
+    with
+        KeyValueMixin<ILocalConfigStorage>,
+        KeyValueWritableMixin<ILocalConfigStorage> {
   historicSize,
   lastAppReviewAt,
   defaultRegion;
@@ -16,4 +19,6 @@ enum LocalConfig with KeyValueMixin<ILocalConfigStorage>, KeyValueWritableMixin<
   Future<ILocalConfigStorage> get storage => di.lazyGet();
 }
 
-Map<String, dynamic> get localConfigDefaults => {LocalConfig.historicSize.key: 0};
+Map<String, dynamic> get localConfigDefaults => {
+  LocalConfig.historicSize.key: 0,
+};

--- a/lib/common/di/definition.dart
+++ b/lib/common/di/definition.dart
@@ -19,7 +19,11 @@ void registerSingleton<T extends Object>(
   DisposingFunc<T>? dispose,
 }) {
   if (dependsOn?.isNotEmpty == true) {
-    return getIt.registerSingletonWithDependencies(factoryFunc, dependsOn: dependsOn, dispose: dispose);
+    return getIt.registerSingletonWithDependencies(
+      factoryFunc,
+      dependsOn: dependsOn,
+      dispose: dispose,
+    );
   }
 
   return getIt.registerLazySingleton(factoryFunc, dispose: dispose);

--- a/lib/common/di/inject.dart
+++ b/lib/common/di/inject.dart
@@ -3,7 +3,8 @@ import 'package:get_it/get_it.dart';
 
 final getIt = GetIt.instance;
 
-T get<T extends Object>({dynamic param1, dynamic param2}) => getIt.get<T>(param1: param1, param2: param2);
+T get<T extends Object>({dynamic param1, dynamic param2}) =>
+    getIt.get<T>(param1: param1, param2: param2);
 
 Future<T> lazyGet<T extends Object>() => getIt.getAsync<T>();
 
@@ -12,5 +13,6 @@ extension StatefulDiExt<S extends StatefulWidget> on State<S> {
 }
 
 extension StatelessDiExt on StatelessWidget {
-  T inject<T extends Object>({dynamic param1, dynamic param2}) => getIt<T>(param1: param1, param2: param2);
+  T inject<T extends Object>({dynamic param1, dynamic param2}) =>
+      getIt<T>(param1: param1, param2: param2);
 }

--- a/lib/common/di/provider.dart
+++ b/lib/common/di/provider.dart
@@ -5,7 +5,8 @@ import 'inject.dart';
 export 'package:provider/provider.dart' hide ProxyProvider;
 
 class ProxyProvider<Base, Child extends Base> extends Provider<Base> {
-  ProxyProvider({super.key, super.child}) : super(create: (context) => Provider.of<Child>(context, listen: false));
+  ProxyProvider({super.key, super.child})
+    : super(create: (context) => Provider.of<Child>(context, listen: false));
 }
 
 class DiProvider<T extends Object> extends Provider<T> {

--- a/lib/common/ext/future.dart
+++ b/lib/common/ext/future.dart
@@ -4,7 +4,9 @@ typedef OnValue<T, R> = FutureOr<R> Function(T value);
 typedef OnNullValue<T> = FutureOr<T> Function();
 
 extension FutureExt<T extends Object> on Future<T?> {
-  Future<R?> thenIfNotNull<R>(OnValue<T, R> onValue) => then((value) => value != null ? onValue(value) : null);
+  Future<R?> thenIfNotNull<R>(OnValue<T, R> onValue) =>
+      then((value) => value != null ? onValue(value) : null);
 
-  Future<T> orDefault(OnNullValue<T> onNullValue) => then<T>((v) => v ?? onNullValue());
+  Future<T> orDefault(OnNullValue<T> onNullValue) =>
+      then<T>((v) => v ?? onNullValue());
 }

--- a/lib/common/resources/localizations.dart
+++ b/lib/common/resources/localizations.dart
@@ -5,7 +5,8 @@ import 'l10n/generated/app_localizations.dart';
 export 'l10n/generated/app_localizations.dart';
 
 extension AppLocalizationsExt on AppLocalizations {
-  String formatDate(DateTime dt) => DateFormat(_formatFrom(dt), localeName).format(dt);
+  String formatDate(DateTime dt) =>
+      DateFormat(_formatFrom(dt), localeName).format(dt);
 
   String _formatFrom(DateTime dt) {
     final now = DateTime.now();
@@ -14,7 +15,9 @@ extension AppLocalizationsExt on AppLocalizations {
     }
 
     final yesterday = now.subtract(const Duration(days: 1));
-    if (dt.day == yesterday.day && dt.month == yesterday.month && dt.year == yesterday.year) {
+    if (dt.day == yesterday.day &&
+        dt.month == yesterday.month &&
+        dt.year == yesterday.year) {
       return this.yesterday;
     }
 

--- a/lib/common/resources/theme.dart
+++ b/lib/common/resources/theme.dart
@@ -16,7 +16,10 @@ abstract class AppTheme {
       ),
       scaffoldBackgroundColor: Colors.white,
       textTheme: GoogleFonts.getTextTheme('Archivo', base.textTheme),
-      tabBarTheme: base.tabBarTheme.copyWith(labelColor: Colors.teal, unselectedLabelColor: Colors.blueGrey),
+      tabBarTheme: base.tabBarTheme.copyWith(
+        labelColor: Colors.teal,
+        unselectedLabelColor: Colors.blueGrey,
+      ),
     );
   }
 

--- a/lib/common/services/firebase.dart
+++ b/lib/common/services/firebase.dart
@@ -9,7 +9,9 @@ FirebaseCrashlytics get crashlytics => FirebaseCrashlytics.instance;
 
 FirebasePerformance get performance => FirebasePerformance.instance;
 
-Future<FirebaseRemoteConfig> getRemoteConfig(Map<String, dynamic> defaults) async {
+Future<FirebaseRemoteConfig> getRemoteConfig(
+  Map<String, dynamic> defaults,
+) async {
   final remoteConfig = FirebaseRemoteConfig.instance;
 
   await remoteConfig.setDefaults(defaults);
@@ -23,7 +25,10 @@ Future<FirebaseRemoteConfig> getRemoteConfig(Map<String, dynamic> defaults) asyn
 void _fetch(FirebaseRemoteConfig remoteConfig) async {
   try {
     await remoteConfig.setConfigSettings(
-      RemoteConfigSettings(fetchTimeout: const Duration(minutes: 1), minimumFetchInterval: const Duration(days: 1)),
+      RemoteConfigSettings(
+        fetchTimeout: const Duration(minutes: 1),
+        minimumFetchInterval: const Duration(days: 1),
+      ),
     );
     await remoteConfig.fetch();
   } catch (error, stack) {

--- a/lib/common/services/share_service.dart
+++ b/lib/common/services/share_service.dart
@@ -13,6 +13,8 @@ class ShareService {
       Log.e(e, stack);
     }
 
-    yield* ReceiveIntent.receivedIntentStream.where((event) => event != null).cast<Intent>();
+    yield* ReceiveIntent.receivedIntentStream
+        .where((event) => event != null)
+        .cast<Intent>();
   }
 }

--- a/lib/common/widgets/feedback_view.dart
+++ b/lib/common/widgets/feedback_view.dart
@@ -23,12 +23,17 @@ class FeedbackView extends StatelessWidget {
           Text(
             text,
             textAlign: TextAlign.center,
-            style: textTheme.titleLarge?.copyWith(color: textTheme.titleLarge?.color?.withValues(alpha: .6)),
+            style: textTheme.titleLarge?.copyWith(
+              color: textTheme.titleLarge?.color?.withValues(alpha: .6),
+            ),
           ),
           if (button != null)
             Container(
               margin: const EdgeInsets.only(top: 8),
-              child: ElevatedButton(onPressed: button.onClick, child: Text(button.text.toUpperCase())),
+              child: ElevatedButton(
+                onPressed: button.onClick,
+                child: Text(button.text.toUpperCase()),
+              ),
             ),
         ],
       ),
@@ -37,7 +42,8 @@ class FeedbackView extends StatelessWidget {
 }
 
 class ErrorFeedbackView extends FeedbackView {
-  const ErrorFeedbackView._(String text, FeedbackButton? button) : super(text: text, button: button);
+  const ErrorFeedbackView._(String text, FeedbackButton? button)
+    : super(text: text, button: button);
 
   factory ErrorFeedbackView(
     BuildContext context, {
@@ -45,11 +51,16 @@ class ErrorFeedbackView extends FeedbackView {
     required VoidCallback? onRetryPressed,
     ErrorConverterRegistry? additionalRegistry,
   }) {
-    final failure = get<FailureAdapter>(param1: additionalRegistry).adapt(context, error);
+    final failure = get<FailureAdapter>(
+      param1: additionalRegistry,
+    ).adapt(context, error);
 
     final button =
         onRetryPressed != null && failure is ErrorFeedback
-            ? FeedbackButton(text: failure.primaryButtonText, onClick: onRetryPressed)
+            ? FeedbackButton(
+              text: failure.primaryButtonText,
+              onClick: onRetryPressed,
+            )
             : null;
 
     return ErrorFeedbackView._(failure.message, button);

--- a/lib/common/widgets/image_resolver_widget.dart
+++ b/lib/common/widgets/image_resolver_widget.dart
@@ -3,10 +3,26 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:logify/logify.dart';
 
 class ImageResolverWidget extends StatelessWidget {
-  ImageResolverWidget({Key? key, required this.uri, this.color, this.height, this.width}) : super(key: key);
+  ImageResolverWidget({
+    Key? key,
+    required this.uri,
+    this.color,
+    this.height,
+    this.width,
+  }) : super(key: key);
 
-  factory ImageResolverWidget.icon({Key? key, required Uri uri, Color? color, double size = 24}) =>
-      ImageResolverWidget(key: key, uri: uri, color: color, height: size, width: size);
+  factory ImageResolverWidget.icon({
+    Key? key,
+    required Uri uri,
+    Color? color,
+    double size = 24,
+  }) => ImageResolverWidget(
+    key: key,
+    uri: uri,
+    color: color,
+    height: size,
+    width: size,
+  );
 
   final Uri uri;
   final Color? color;
@@ -15,7 +31,8 @@ class ImageResolverWidget extends StatelessWidget {
 
   late final _extension = uri.path.split('.').last;
   late final _isSvg = _extension == 'svg';
-  late final _colorFilter = color != null ? ColorFilter.mode(color!, BlendMode.srcIn) : null;
+  late final _colorFilter =
+      color != null ? ColorFilter.mode(color!, BlendMode.srcIn) : null;
 
   @override
   Widget build(BuildContext context) {
@@ -33,14 +50,24 @@ class ImageResolverWidget extends StatelessWidget {
   Widget _fromNetwork() {
     final color = this.color;
     return _isSvg
-        ? SvgPicture.network('$uri', height: height, width: width, colorFilter: _colorFilter)
+        ? SvgPicture.network(
+          '$uri',
+          height: height,
+          width: width,
+          colorFilter: _colorFilter,
+        )
         : Image.network('$uri', color: color, height: height, width: width);
   }
 
   Widget _fromAssets() {
     final path = uri.toString().replaceFirst(':/', '');
     return _isSvg
-        ? SvgPicture.asset(path, height: height, width: width, colorFilter: _colorFilter)
+        ? SvgPicture.asset(
+          path,
+          height: height,
+          width: width,
+          colorFilter: _colorFilter,
+        )
         : Image.asset(path, color: color, height: height, width: width);
   }
 }

--- a/lib/common/widgets/shimmer_view.dart
+++ b/lib/common/widgets/shimmer_view.dart
@@ -13,7 +13,14 @@ class ShimmerView extends StatelessWidget {
     return Shimmer.fromColors(
       baseColor: const Color(0xFFD6D6D6),
       highlightColor: Colors.grey.shade200,
-      child: ImageFiltered(imageFilter: ImageFilter.blur(sigmaX: 5, sigmaY: 4, tileMode: TileMode.decal), child: child),
+      child: ImageFiltered(
+        imageFilter: ImageFilter.blur(
+          sigmaX: 5,
+          sigmaY: 4,
+          tileMode: TileMode.decal,
+        ),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/common/widgets/tab_page.dart
+++ b/lib/common/widgets/tab_page.dart
@@ -21,7 +21,10 @@ class TabListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<TabPage>>(future: _filteredTabs, builder: (_, snapshot) => _buildTabs(snapshot));
+    return FutureBuilder<List<TabPage>>(
+      future: _filteredTabs,
+      builder: (_, snapshot) => _buildTabs(snapshot),
+    );
   }
 
   Stream<TabPage> _filterAvailableTabs() async* {
@@ -65,7 +68,10 @@ class _SingleTabPage extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Text(page.buildTitle(context), style: theme.textTheme.titleLarge),
+          child: Text(
+            page.buildTitle(context),
+            style: theme.textTheme.titleLarge,
+          ),
         ),
         Expanded(child: page),
       ],
@@ -78,13 +84,18 @@ class _MultiTabPage extends StatelessWidget {
 
   final List<TabPage> tabs;
 
-  late final List<Tab> tabSelectors = tabs.map((tab) => Tab(child: _TabIndicatorView(tab))).toList(growable: false);
+  late final List<Tab> tabSelectors = tabs
+      .map((tab) => Tab(child: _TabIndicatorView(tab)))
+      .toList(growable: false);
 
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: tabs.length,
-      child: Scaffold(appBar: TabBar(tabs: tabSelectors), body: TabBarView(children: tabs)),
+      child: Scaffold(
+        appBar: TabBar(tabs: tabSelectors),
+        body: TabBarView(children: tabs),
+      ),
     );
   }
 }
@@ -98,7 +109,11 @@ class _TabIndicatorView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: [Icon(tab.icon), const SizedBox(width: 8), Text(tab.buildTitle(context))],
+      children: [
+        Icon(tab.icon),
+        const SizedBox(width: 8),
+        Text(tab.buildTitle(context)),
+      ],
     );
   }
 }

--- a/lib/features/call_log/call_log_module.dart
+++ b/lib/features/call_log/call_log_module.dart
@@ -7,9 +7,18 @@ import 'domain/usecase/request_call_log_permission.dart';
 import 'presentation/call_log_bloc.dart';
 
 void callLogModule() {
-  registerFactory(() => CallLogBloc(getCallLog: get(), requestCallLogPermission: get(), analytics: get()));
+  registerFactory(
+    () => CallLogBloc(
+      getCallLog: get(),
+      requestCallLogPermission: get(),
+      analytics: get(),
+    ),
+  );
 
-  registerFactory(() => GetCallLogUseCase(hasCallLogAccessPermission: get(), repository: get()));
+  registerFactory(
+    () =>
+        GetCallLogUseCase(hasCallLogAccessPermission: get(), repository: get()),
+  );
 
   registerFactory(() => HasCallLogAccessPermissionUseCase());
 

--- a/lib/features/call_log/domain/entity/call.dart
+++ b/lib/features/call_log/domain/entity/call.dart
@@ -1,7 +1,12 @@
 import 'package:equatable/equatable.dart';
 
 class CallEntity extends Equatable {
-  const CallEntity({required this.name, required this.number, required this.date, required this.type});
+  const CallEntity({
+    required this.name,
+    required this.number,
+    required this.date,
+    required this.type,
+  });
 
   final String? name;
   final String number;

--- a/lib/features/call_log/domain/usecase/get_call_log.dart
+++ b/lib/features/call_log/domain/usecase/get_call_log.dart
@@ -4,7 +4,10 @@ import '../repository/call_log.dart';
 import 'has_call_log_access_permission.dart';
 
 class GetCallLogUseCase {
-  GetCallLogUseCase({required this.hasCallLogAccessPermission, required this.repository});
+  GetCallLogUseCase({
+    required this.hasCallLogAccessPermission,
+    required this.repository,
+  });
 
   final HasCallLogAccessPermissionUseCase hasCallLogAccessPermission;
   final CallLogRepository repository;

--- a/lib/features/call_log/presentation/call_log_bloc.dart
+++ b/lib/features/call_log/presentation/call_log_bloc.dart
@@ -29,7 +29,12 @@ class CallLogBloc extends StateActionBloc<CallLogState, CallLogAction> {
   Future<void> load() async {
     final state = await _getCallLog()
         .then((items) => items.map((e) => CallEntry.from(e)))
-        .then((items) => items.isNotEmpty ? CallLogState(entries: items) : CallLogState.empty())
+        .then(
+          (items) =>
+              items.isNotEmpty
+                  ? CallLogState(entries: items)
+                  : CallLogState.empty(),
+        )
         .catchError(_onError);
 
     setState(state);

--- a/lib/features/call_log/presentation/call_log_page.dart
+++ b/lib/features/call_log/presentation/call_log_page.dart
@@ -23,30 +23,35 @@ class CallLogTabPage extends StatelessWidget
   late final IconData icon = Icons.call;
 
   @override
-  late final Future<bool> isTabAvailable = RemoteConfig.isCallLogTabEnabled.get();
+  late final Future<bool> isTabAvailable =
+      RemoteConfig.isCallLogTabEnabled.get();
 
   @override
   String buildTitle(BuildContext context) => context.strings.callLogTabTitle;
 
   @override
-  Widget buildState(BuildContext context, CallLogState state) => switch (state) {
-    LoadedCallLogState(:final entries) => _SuccessView(entries),
-    LoadingCallLogState(:final itemCount) => _LoadingView(itemCount),
-    EmptyCallLogState() => FeedbackView(text: context.strings.callLogEmptyMessage),
-    ErrorCallLogState(:final error) => ErrorFeedbackView(
-      context,
-      error: error,
-      onRetryPressed: () => context.read<CallLogBloc>().retry(),
-      additionalRegistry: CallLogErrorConverterRegistry(),
-    ),
-  };
+  Widget buildState(BuildContext context, CallLogState state) =>
+      switch (state) {
+        LoadedCallLogState(:final entries) => _SuccessView(entries),
+        LoadingCallLogState(:final itemCount) => _LoadingView(itemCount),
+        EmptyCallLogState() => FeedbackView(
+          text: context.strings.callLogEmptyMessage,
+        ),
+        ErrorCallLogState(:final error) => ErrorFeedbackView(
+          context,
+          error: error,
+          onRetryPressed: () => context.read<CallLogBloc>().retry(),
+          additionalRegistry: CallLogErrorConverterRegistry(),
+        ),
+      };
 
   @override
-  FutureOr<void> handleAction(BuildContext context, CallLogAction action) => switch (action) {
-    SelectEntryCallLogAction(:final entry) => context.read<CallLogMediator>().onPhoneReceivedFromCallLog(
-      entry.phoneNumber,
-    ),
-  };
+  FutureOr<void> handleAction(BuildContext context, CallLogAction action) =>
+      switch (action) {
+        SelectEntryCallLogAction(:final entry) => context
+            .read<CallLogMediator>()
+            .onPhoneReceivedFromCallLog(entry.phoneNumber),
+      };
 }
 
 class _SuccessView extends StatelessWidget {
@@ -97,7 +102,10 @@ class _EntryView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: CircleAvatar(backgroundColor: entry.leading.color, child: Icon(entry.leading.icon, color: Colors.white)),
+      leading: CircleAvatar(
+        backgroundColor: entry.leading.color,
+        child: Icon(entry.leading.icon, color: Colors.white),
+      ),
       title: Text(entry.title),
       subtitle: Text(entry.subtitle ?? context.strings.formatDate(entry.date)),
       onTap: () => context.read<CallLogBloc>().selected(entry),

--- a/lib/features/call_log/presentation/call_log_state.dart
+++ b/lib/features/call_log/presentation/call_log_state.dart
@@ -8,7 +8,8 @@ part 'call_log_state.freezed.dart';
 
 @freezed
 sealed class CallLogState with _$CallLogState implements IState {
-  factory CallLogState({required Iterable<CallEntry> entries}) = LoadedCallLogState;
+  factory CallLogState({required Iterable<CallEntry> entries}) =
+      LoadedCallLogState;
 
   factory CallLogState.empty() = EmptyCallLogState;
 
@@ -23,10 +24,20 @@ sealed class CallLogAction with _$CallLogAction implements IAction {
 }
 
 class CallEntry {
-  CallEntry({required this.leading, required this.title, this.subtitle, required this.date, required this.phoneNumber});
+  CallEntry({
+    required this.leading,
+    required this.title,
+    this.subtitle,
+    required this.date,
+    required this.phoneNumber,
+  });
 
-  factory CallEntry.from(CallEntity item) =>
-      CallEntry(leading: item.type.leading, title: item.name ?? item.number, date: item.date, phoneNumber: item.number);
+  factory CallEntry.from(CallEntity item) => CallEntry(
+    leading: item.type.leading,
+    title: item.name ?? item.number,
+    date: item.date,
+    phoneNumber: item.number,
+  );
 
   final Leading leading;
   final String title;

--- a/lib/features/chat_app/chat_app_module.dart
+++ b/lib/features/chat_app/chat_app_module.dart
@@ -11,8 +11,12 @@ import 'presentation/chat_app_bloc.dart';
 
 void chatAppModule() {
   registerFactory(
-    () =>
-        ChatAppBloc(getEnabledChatApps: get(), getDisabledChatApps: get(), disableChatApp: get(), enableChatApp: get()),
+    () => ChatAppBloc(
+      getEnabledChatApps: get(),
+      getDisabledChatApps: get(),
+      disableChatApp: get(),
+      enableChatApp: get(),
+    ),
   );
 
   registerFactory(() => GetEnabledChatAppsUseCase(repository: get()));
@@ -23,7 +27,9 @@ void chatAppModule() {
 
   registerFactory(() => EnableChatAppUseCase(repository: get()));
 
-  registerFactory<IChatAppRepository>(() => ChatAppRepository(dataSource: get()));
+  registerFactory<IChatAppRepository>(
+    () => ChatAppRepository(dataSource: get()),
+  );
 
   registerSingleton<IChatAppDataSource>(() => ChatAppDataSource(db: lazy()));
 }

--- a/lib/features/chat_app/data/datasource/impl/chat_app_datasource.dart
+++ b/lib/features/chat_app/data/datasource/impl/chat_app_datasource.dart
@@ -54,6 +54,10 @@ class ChatAppDataSource extends IChatAppDataSource {
   @override
   Future<void> remove(ChatApp chatApp) async {
     final db = await _db;
-    await db.delete('enabled_chat_app', where: 'chat_app_id = ?', whereArgs: [chatApp.id]);
+    await db.delete(
+      'enabled_chat_app',
+      where: 'chat_app_id = ?',
+      whereArgs: [chatApp.id],
+    );
   }
 }

--- a/lib/features/chat_app/data/repository/chat_app_repository.dart
+++ b/lib/features/chat_app/data/repository/chat_app_repository.dart
@@ -3,7 +3,8 @@ import '../../domain/repository/chat_app_repository.dart';
 import '../datasource/chat_app_datasource.dart';
 
 class ChatAppRepository extends IChatAppRepository {
-  ChatAppRepository({required IChatAppDataSource dataSource}) : _dataSource = dataSource;
+  ChatAppRepository({required IChatAppDataSource dataSource})
+    : _dataSource = dataSource;
 
   final IChatAppDataSource _dataSource;
 

--- a/lib/features/chat_app/domain/disable_chat_app.dart
+++ b/lib/features/chat_app/domain/disable_chat_app.dart
@@ -2,7 +2,8 @@ import 'entity/chat_app.dart';
 import 'repository/chat_app_repository.dart';
 
 class DisableChatAppUseCase {
-  const DisableChatAppUseCase({required IChatAppRepository repository}) : _repository = repository;
+  const DisableChatAppUseCase({required IChatAppRepository repository})
+    : _repository = repository;
 
   final IChatAppRepository _repository;
 

--- a/lib/features/chat_app/domain/enable_chat_app.dart
+++ b/lib/features/chat_app/domain/enable_chat_app.dart
@@ -2,7 +2,8 @@ import 'entity/chat_app.dart';
 import 'repository/chat_app_repository.dart';
 
 class EnableChatAppUseCase {
-  const EnableChatAppUseCase({required IChatAppRepository repository}) : _repository = repository;
+  const EnableChatAppUseCase({required IChatAppRepository repository})
+    : _repository = repository;
 
   final IChatAppRepository _repository;
 

--- a/lib/features/chat_app/domain/entity/color.dart
+++ b/lib/features/chat_app/domain/entity/color.dart
@@ -15,7 +15,10 @@ class Color extends Equatable {
 
   factory Color.fromString(String hexColor) {
     final value = hexColor.replaceFirst('#', '');
-    assert(value.length >= 6 && value.length <= 8, 'Invalid value for color: "$hexColor"');
+    assert(
+      value.length >= 6 && value.length <= 8,
+      'Invalid value for color: "$hexColor"',
+    );
     return Color._(int.parse(value, radix: 16));
   }
 

--- a/lib/features/chat_app/domain/get_disabled_chat_apps.dart
+++ b/lib/features/chat_app/domain/get_disabled_chat_apps.dart
@@ -2,10 +2,12 @@ import 'entity/chat_app.dart';
 import 'repository/chat_app_repository.dart';
 
 class GetDisabledChatAppsUseCase {
-  const GetDisabledChatAppsUseCase({required IChatAppRepository repository}) : _repository = repository;
+  const GetDisabledChatAppsUseCase({required IChatAppRepository repository})
+    : _repository = repository;
 
   final IChatAppRepository _repository;
 
-  Stream<Iterable<ChatApp>> call() =>
-      _repository.getAll().map((actions) => actions.skipWhile((action) => action.isEnabled));
+  Stream<Iterable<ChatApp>> call() => _repository.getAll().map(
+    (actions) => actions.skipWhile((action) => action.isEnabled),
+  );
 }

--- a/lib/features/chat_app/domain/get_enabled_chat_apps.dart
+++ b/lib/features/chat_app/domain/get_enabled_chat_apps.dart
@@ -2,10 +2,12 @@ import 'entity/chat_app.dart';
 import 'repository/chat_app_repository.dart';
 
 class GetEnabledChatAppsUseCase {
-  const GetEnabledChatAppsUseCase({required IChatAppRepository repository}) : _repository = repository;
+  const GetEnabledChatAppsUseCase({required IChatAppRepository repository})
+    : _repository = repository;
 
   final IChatAppRepository _repository;
 
-  Stream<Iterable<ChatApp>> call() =>
-      _repository.getAll().map((actions) => actions.takeWhile((action) => action.isEnabled));
+  Stream<Iterable<ChatApp>> call() => _repository.getAll().map(
+    (actions) => actions.takeWhile((action) => action.isEnabled),
+  );
 }

--- a/lib/features/chat_app/presentation/chat_app_bloc.dart
+++ b/lib/features/chat_app/presentation/chat_app_bloc.dart
@@ -27,13 +27,21 @@ class ChatAppBloc extends StateBloc<ChatAppState> {
 
   @override
   Future<void> load() async {
-    setStateFrom(ZipStream.zip2(_getEnabledChatApps(), _getDisabledChatApps(), _mapToState));
+    setStateFrom(
+      ZipStream.zip2(
+        _getEnabledChatApps(),
+        _getDisabledChatApps(),
+        _mapToState,
+      ),
+    );
   }
 
   Future<void> disable(ChatApp chatApp) => _disableChatApp(chatApp);
 
   Future<void> enable(ChatApp chatApp) => _enableChatApp(chatApp);
 
-  ChatAppState _mapToState(Iterable<ChatApp> enabled, Iterable<ChatApp> disabled) =>
-      ChatAppState(enabled: enabled, disabled: disabled);
+  ChatAppState _mapToState(
+    Iterable<ChatApp> enabled,
+    Iterable<ChatApp> disabled,
+  ) => ChatAppState(enabled: enabled, disabled: disabled);
 }

--- a/lib/features/chat_app/presentation/chat_app_page.dart
+++ b/lib/features/chat_app/presentation/chat_app_page.dart
@@ -18,22 +18,26 @@ class ChatAppSettingsPage extends StatelessWidget {
   );
 }
 
-class _ChatAppSettingsContent extends StatelessWidget with StateMixin<ChatAppBloc, ChatAppState> {
+class _ChatAppSettingsContent extends StatelessWidget
+    with StateMixin<ChatAppBloc, ChatAppState> {
   const _ChatAppSettingsContent();
 
   @override
   Widget buildState(BuildContext context, ChatAppState state) {
     return ListView(
       children: [
-        if (state.enabled.isNotEmpty) _SectionHeader(title: context.strings.messagingAppsEnabledHeader),
+        if (state.enabled.isNotEmpty)
+          _SectionHeader(title: context.strings.messagingAppsEnabledHeader),
         ...state.enabled.map(_mapItemToWidget),
-        if (state.disabled.isNotEmpty) _SectionHeader(title: context.strings.messagingAppsDisabledHeader),
+        if (state.disabled.isNotEmpty)
+          _SectionHeader(title: context.strings.messagingAppsDisabledHeader),
         ...state.disabled.map(_mapItemToWidget),
       ],
     );
   }
 
-  Widget _mapItemToWidget(ChatApp item) => _ChatAppItem(key: ValueKey('chat-app:${item.id}'), item: item);
+  Widget _mapItemToWidget(ChatApp item) =>
+      _ChatAppItem(key: ValueKey('chat-app:${item.id}'), item: item);
 }
 
 class _SectionHeader extends StatelessWidget {
@@ -42,15 +46,23 @@ class _SectionHeader extends StatelessWidget {
   final String title;
 
   @override
-  Widget build(BuildContext context) => ListTile(title: Text(title, style: Theme.of(context).textTheme.titleLarge));
+  Widget build(BuildContext context) => ListTile(
+    title: Text(title, style: Theme.of(context).textTheme.titleLarge),
+  );
 }
 
 class _ChatAppItem extends ListTile {
   _ChatAppItem({required ChatApp item, super.key})
     : super(
-        leading: ImageResolverWidget.icon(uri: item.icon, color: Color(item.color.value)),
+        leading: ImageResolverWidget.icon(
+          uri: item.icon,
+          color: Color(item.color.value),
+        ),
         title: Text(item.name),
-        trailing: item.isEnabled ? _ButtonDisable(item: item) : _ButtonEnable(item: item),
+        trailing:
+            item.isEnabled
+                ? _ButtonDisable(item: item)
+                : _ButtonEnable(item: item),
       );
 }
 

--- a/lib/features/chat_app/presentation/chat_app_state.dart
+++ b/lib/features/chat_app/presentation/chat_app_state.dart
@@ -7,6 +7,8 @@ part 'chat_app_state.freezed.dart';
 
 @freezed
 sealed class ChatAppState with _$ChatAppState implements IState {
-  factory ChatAppState({@Default([]) Iterable<ChatApp> enabled, @Default([]) Iterable<ChatApp> disabled}) =
-      _ChatAppState;
+  factory ChatAppState({
+    @Default([]) Iterable<ChatApp> enabled,
+    @Default([]) Iterable<ChatApp> disabled,
+  }) = _ChatAppState;
 }

--- a/lib/features/history/data/repository/history_repository.dart
+++ b/lib/features/history/data/repository/history_repository.dart
@@ -14,7 +14,9 @@ class HistoryRepository implements IHistoryRepository {
 
   @override
   Stream<List<HistoryEntry>> getAll() => _db.asStream().asyncExpand(
-    (db) => db.createQuery('historic', orderBy: 'last_usage_at DESC').mapToList(HistoryEntry.fromJson),
+    (db) => db
+        .createQuery('historic', orderBy: 'last_usage_at DESC')
+        .mapToList(HistoryEntry.fromJson),
   );
 
   @override
@@ -34,7 +36,11 @@ class HistoryRepository implements IHistoryRepository {
   @override
   Future<void> remove(HistoryEntry entry) async {
     final db = await _db;
-    await db.delete('historic', where: 'number = ?', whereArgs: [entry.phoneNumber]);
+    await db.delete(
+      'historic',
+      where: 'number = ?',
+      whereArgs: [entry.phoneNumber],
+    );
     _updateHistoricSize(db);
   }
 

--- a/lib/features/history/domain/entity/history.dart
+++ b/lib/features/history/domain/entity/history.dart
@@ -1,5 +1,9 @@
 class HistoryEntry {
-  HistoryEntry({required this.phoneNumber, required this.lastUsageAt, required this.createdAt});
+  HistoryEntry({
+    required this.phoneNumber,
+    required this.lastUsageAt,
+    required this.createdAt,
+  });
 
   factory HistoryEntry.fromJson(Map<String, dynamic> json) {
     return HistoryEntry(
@@ -18,9 +22,11 @@ class HistoryEntry {
 
   @override
   bool operator ==(Object other) {
-    return super == other || (other is HistoryEntry && other.phoneNumber == phoneNumber);
+    return super == other ||
+        (other is HistoryEntry && other.phoneNumber == phoneNumber);
   }
 
   @override
-  String toString() => 'HistoryEntry{phoneNumber: $phoneNumber, lastUsageAt: $lastUsageAt, createdAt: $createdAt}';
+  String toString() =>
+      'HistoryEntry{phoneNumber: $phoneNumber, lastUsageAt: $lastUsageAt, createdAt: $createdAt}';
 }

--- a/lib/features/history/presentation/history_bloc.dart
+++ b/lib/features/history/presentation/history_bloc.dart
@@ -38,7 +38,10 @@ class HistoryBloc extends StateActionBloc<HistoryState, HistoryAction> {
   Future<void> load() async {
     final historicSize = await _historicSize();
 
-    final initialState = historicSize > 0 ? HistoryState.loading(historicSize) : HistoryState.empty();
+    final initialState =
+        historicSize > 0
+            ? HistoryState.loading(historicSize)
+            : HistoryState.empty();
 
     setState(initialState);
 
@@ -56,10 +59,19 @@ class HistoryBloc extends StateActionBloc<HistoryState, HistoryAction> {
 
   void longPress(HistoryEntry entry) {
     _analytics.itemLongPressed('phone_from_history');
-    sendAction(HistoryAction.showMenu(entry, _currentTapPosition, ContextMenuAction.values));
+    sendAction(
+      HistoryAction.showMenu(
+        entry,
+        _currentTapPosition,
+        ContextMenuAction.values,
+      ),
+    );
   }
 
-  Future<void> selectOption(HistoryEntry entry, ContextMenuAction? action) async {
+  Future<void> selectOption(
+    HistoryEntry entry,
+    ContextMenuAction? action,
+  ) async {
     switch (action) {
       case ContextMenuAction.remove:
         await remove(entry);
@@ -82,7 +94,8 @@ class HistoryBloc extends StateActionBloc<HistoryState, HistoryAction> {
   }
 
   Future<HistoryState> _mapToState(List<HistoryEntry> entries) async {
-    final isCallLogTabEnabled = await RemoteConfig.isCallLogTabEnabled.get<bool>();
+    final isCallLogTabEnabled =
+        await RemoteConfig.isCallLogTabEnabled.get<bool>();
 
     final adOptions = AdOptions(
       unitId: await RemoteConfig.homeAdListUnitId.get(),
@@ -90,7 +103,11 @@ class HistoryBloc extends StateActionBloc<HistoryState, HistoryAction> {
     );
 
     return entries.isNotEmpty
-        ? HistoryState(entries: entries, isDismissible: !isCallLogTabEnabled, adOptions: adOptions)
+        ? HistoryState(
+          entries: entries,
+          isDismissible: !isCallLogTabEnabled,
+          adOptions: adOptions,
+        )
         : HistoryState.empty();
   }
 

--- a/lib/features/history/presentation/history_page.dart
+++ b/lib/features/history/presentation/history_page.dart
@@ -27,28 +27,41 @@ class HistoryPage extends StatelessWidget
   String buildTitle(BuildContext context) => context.strings.recentNumbersTitle;
 
   @override
-  Widget buildState(BuildContext context, HistoryState state) => switch (state) {
-    LoadedHistoryState(:final entries, :final adOptions, :final isDismissible) => _SuccessView(
-      entries,
-      adOptions: adOptions,
-      isDismissible: isDismissible,
-    ),
+  Widget buildState(
+    BuildContext context,
+    HistoryState state,
+  ) => switch (state) {
+    LoadedHistoryState(
+      :final entries,
+      :final adOptions,
+      :final isDismissible,
+    ) =>
+      _SuccessView(entries, adOptions: adOptions, isDismissible: isDismissible),
     LoadingHistoryState(:final size) => _LoadingView(size),
-    EmptyHistoryState() => FeedbackView(text: context.strings.recentNumbersEmpty),
+    EmptyHistoryState() => FeedbackView(
+      text: context.strings.recentNumbersEmpty,
+    ),
   };
 
   @override
-  FutureOr<void> handleAction(BuildContext context, HistoryAction action) async => switch (action) {
-    SelectEntryHistoryAction(:final entry) => context.read<HistoryMediator>().onPhoneReceivedFromHistory(
-      entry.phoneNumber,
-    ),
-    ShowMenuHistoryAction(:final entry, :final position, :final options) => showContextMenu(
+  FutureOr<void> handleAction(
+    BuildContext context,
+    HistoryAction action,
+  ) async => switch (action) {
+    SelectEntryHistoryAction(:final entry) => context
+        .read<HistoryMediator>()
+        .onPhoneReceivedFromHistory(entry.phoneNumber),
+    ShowMenuHistoryAction(:final entry, :final position, :final options) =>
+      showContextMenu(
+        context,
+        entry: entry,
+        tapPosition: position,
+        options: options,
+      ),
+    AskToRestoreEntryHistoryAction(:final entry) => _showRestoreEntrySnackBar(
       context,
-      entry: entry,
-      tapPosition: position,
-      options: options,
+      entry,
     ),
-    AskToRestoreEntryHistoryAction(:final entry) => _showRestoreEntrySnackBar(context, entry),
   };
 
   void _showRestoreEntrySnackBar(BuildContext context, HistoryEntry entry) {
@@ -99,15 +112,23 @@ class _LoadingView extends StatelessWidget {
     return ListView.separated(
       itemCount: itemCount,
       itemBuilder:
-          (_, __) =>
-              const ShimmerView(child: ListTile(title: Text('■■■ ■■ ■■■■■-■■■■'), trailing: Text('■■■ ■■■■ ■■■'))),
+          (_, __) => const ShimmerView(
+            child: ListTile(
+              title: Text('■■■ ■■ ■■■■■-■■■■'),
+              trailing: Text('■■■ ■■■■ ■■■'),
+            ),
+          ),
       separatorBuilder: (_, __) => const ListDivider(),
     );
   }
 }
 
 class _SuccessView extends StatelessWidget {
-  const _SuccessView(this.entries, {required this.adOptions, required this.isDismissible});
+  const _SuccessView(
+    this.entries, {
+    required this.adOptions,
+    required this.isDismissible,
+  });
 
   final Iterable<HistoryEntry> entries;
   final AdOptions? adOptions;
@@ -149,7 +170,14 @@ class _DismissibleEntryView extends StatelessWidget {
       background: Container(
         color: const Color.fromARGB(255, 186, 12, 0),
         child: const Stack(
-          children: [Positioned(right: 16, top: 0, bottom: 0, child: Icon(Icons.delete, color: Colors.white))],
+          children: [
+            Positioned(
+              right: 16,
+              top: 0,
+              bottom: 0,
+              child: Icon(Icons.delete, color: Colors.white),
+            ),
+          ],
         ),
       ),
       child: _EntryView(entry),
@@ -165,7 +193,8 @@ class _EntryView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: (details) => context.read<HistoryBloc>().tapPositionFrom(details),
+      onTapDown:
+          (details) => context.read<HistoryBloc>().tapPositionFrom(details),
       child: ListTile(
         title: Text(entry.phoneNumber),
         trailing: Timeago(

--- a/lib/features/history/presentation/history_state.dart
+++ b/lib/features/history/presentation/history_state.dart
@@ -23,10 +23,14 @@ sealed class HistoryState with _$HistoryState implements IState {
 sealed class HistoryAction with _$HistoryAction implements IAction {
   factory HistoryAction.select(HistoryEntry entry) = SelectEntryHistoryAction;
 
-  factory HistoryAction.showMenu(HistoryEntry entry, Offset position, Iterable<ContextMenuAction> options) =
-      ShowMenuHistoryAction;
+  factory HistoryAction.showMenu(
+    HistoryEntry entry,
+    Offset position,
+    Iterable<ContextMenuAction> options,
+  ) = ShowMenuHistoryAction;
 
-  factory HistoryAction.showRestoreEntrySnackBar(HistoryEntry entry) = AskToRestoreEntryHistoryAction;
+  factory HistoryAction.showRestoreEntrySnackBar(HistoryEntry entry) =
+      AskToRestoreEntryHistoryAction;
 }
 
 enum ContextMenuAction { remove }
@@ -41,7 +45,9 @@ class AdOptions {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    return other is AdOptions && other.unitId == unitId && other.interval == interval;
+    return other is AdOptions &&
+        other.unitId == unitId &&
+        other.interval == interval;
   }
 
   @override

--- a/lib/features/home/ad_banner/presentation/ad_banner_widget.dart
+++ b/lib/features/home/ad_banner/presentation/ad_banner_widget.dart
@@ -8,17 +8,19 @@ import '../../../../../common/di/inject.dart';
 import 'ad_banner_bloc.dart';
 import 'ad_banner_state.dart';
 
-class AdBannerWidget extends StatelessWidget with StateMixin<AdBannerBloc, AdBannerState> {
+class AdBannerWidget extends StatelessWidget
+    with StateMixin<AdBannerBloc, AdBannerState> {
   AdBannerWidget({Key? key}) : super(key: key);
 
   @override
   late final bloc = inject<AdBannerBloc>();
 
   @override
-  Widget buildState(BuildContext context, AdBannerState state) => switch (state) {
-    LoadedAdBannerState(:final unitId) => _AdBannerWidget(unitId: unitId),
-    NoneAdBannerState() => const SizedBox.shrink(),
-  };
+  Widget buildState(BuildContext context, AdBannerState state) =>
+      switch (state) {
+        LoadedAdBannerState(:final unitId) => _AdBannerWidget(unitId: unitId),
+        NoneAdBannerState() => const SizedBox.shrink(),
+      };
 }
 
 class _AdBannerWidget extends StatefulWidget {

--- a/lib/features/home/chat_apps/chat_apps_module.dart
+++ b/lib/features/home/chat_apps/chat_apps_module.dart
@@ -2,5 +2,7 @@ import '../../../../common/di/definition.dart';
 import 'presentation/chat_apps_bloc.dart';
 
 void chatAppsModule() {
-  registerFactory(() => ChatAppsBloc(getEnabledChatApps: get(), analytics: get()));
+  registerFactory(
+    () => ChatAppsBloc(getEnabledChatApps: get(), analytics: get()),
+  );
 }

--- a/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
@@ -8,10 +8,12 @@ import '../../../chat_app/domain/get_enabled_chat_apps.dart';
 import 'chat_apps_state.dart';
 
 class ChatAppsBloc extends StateActionBloc<ChatAppsState, ChatAppsAction> {
-  ChatAppsBloc({required GetEnabledChatAppsUseCase getEnabledChatApps, required IAnalytics analytics})
-    : _getEnabledChatApps = getEnabledChatApps,
-      _analytics = analytics,
-      super(ChatAppsState.initial());
+  ChatAppsBloc({
+    required GetEnabledChatAppsUseCase getEnabledChatApps,
+    required IAnalytics analytics,
+  }) : _getEnabledChatApps = getEnabledChatApps,
+       _analytics = analytics,
+       super(ChatAppsState.initial());
 
   final GetEnabledChatAppsUseCase _getEnabledChatApps;
   final IAnalytics _analytics;
@@ -22,7 +24,10 @@ class ChatAppsBloc extends StateActionBloc<ChatAppsState, ChatAppsAction> {
   }
 
   void selected(ChatApp entry) {
-    _analytics.buttonPressed('launch_chat_app', properties: {'app_launched': entry.name});
+    _analytics.buttonPressed(
+      'launch_chat_app',
+      properties: {'app_launched': entry.name},
+    );
     sendAction(ChatAppsAction.select(entry));
   }
 
@@ -34,5 +39,6 @@ class ChatAppsBloc extends StateActionBloc<ChatAppsState, ChatAppsAction> {
     }
   }
 
-  ChatAppsState _mapToState(Iterable<ChatApp> entries) => ChatAppsState(entries);
+  ChatAppsState _mapToState(Iterable<ChatApp> entries) =>
+      ChatAppsState(entries);
 }

--- a/lib/features/home/chat_apps/presentation/chat_apps_state.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_state.dart
@@ -15,5 +15,6 @@ sealed class ChatAppsState with _$ChatAppsState implements IState {
 @freezed
 sealed class ChatAppsAction with _$ChatAppsAction implements IAction {
   factory ChatAppsAction.select(ChatApp entry) = SelectEntryChatAppsAction;
-  factory ChatAppsAction.showFailureMessage(ChatApp app) = ShowFailureMessageChatAppsAction;
+  factory ChatAppsAction.showFailureMessage(ChatApp app) =
+      ShowFailureMessageChatAppsAction;
 }

--- a/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
@@ -12,20 +12,26 @@ import 'chat_apps_bloc.dart';
 import 'chat_apps_state.dart';
 import 'dialogs/chat_app_not_found.dart';
 
-class ChatAppsWidget extends StatelessWidget with StateActionMixin<ChatAppsBloc, ChatAppsState, ChatAppsAction> {
+class ChatAppsWidget extends StatelessWidget
+    with StateActionMixin<ChatAppsBloc, ChatAppsState, ChatAppsAction> {
   ChatAppsWidget({Key? key}) : super(key: key);
 
   @override
-  Widget buildState(BuildContext context, ChatAppsState state) => switch (state) {
-    LoadedChatAppsState(:final entries) => _SuccessView(entries),
-    InitialChatAppsState() => const SizedBox.shrink(),
-  };
+  Widget buildState(BuildContext context, ChatAppsState state) =>
+      switch (state) {
+        LoadedChatAppsState(:final entries) => _SuccessView(entries),
+        InitialChatAppsState() => const SizedBox.shrink(),
+      };
 
   @override
-  FutureOr<void> handleAction(BuildContext context, ChatAppsAction action) => switch (action) {
-    SelectEntryChatAppsAction(:final entry) => _openChatApp(context, entry),
-    ShowFailureMessageChatAppsAction(:final app) => _showChatFailureMessage(context, app),
-  };
+  FutureOr<void> handleAction(BuildContext context, ChatAppsAction action) =>
+      switch (action) {
+        SelectEntryChatAppsAction(:final entry) => _openChatApp(context, entry),
+        ShowFailureMessageChatAppsAction(:final app) => _showChatFailureMessage(
+          context,
+          app,
+        ),
+      };
 
   Future<void> _openChatApp(BuildContext context, ChatApp entry) async {
     final chatAppsBloc = context.read<ChatAppsBloc>();
@@ -35,8 +41,14 @@ class ChatAppsWidget extends StatelessWidget with StateActionMixin<ChatAppsBloc,
         .catchError((err, stack) => chatAppsBloc.selectFailed(entry, err));
   }
 
-  Future<void> _showChatFailureMessage(BuildContext context, ChatApp app) async {
-    await showDialog(context: context, builder: (context) => ChatAppNotFoundDialog(app));
+  Future<void> _showChatFailureMessage(
+    BuildContext context,
+    ChatApp app,
+  ) async {
+    await showDialog(
+      context: context,
+      builder: (context) => ChatAppNotFoundDialog(app),
+    );
   }
 }
 
@@ -52,7 +64,9 @@ class _SuccessView extends StatelessWidget {
       padding: const EdgeInsets.only(left: 16, right: 8, bottom: 8),
       child: Row(
         children: entries
-            .mapIndexed((index, entry) => _EntryView(position: index, entry: entry))
+            .mapIndexed(
+              (index, entry) => _EntryView(position: index, entry: entry),
+            )
             .toList(growable: false),
       ),
     );
@@ -60,7 +74,8 @@ class _SuccessView extends StatelessWidget {
 }
 
 class _EntryView extends StatefulWidget {
-  const _EntryView({Key? key, required this.position, required this.entry}) : super(key: key);
+  const _EntryView({Key? key, required this.position, required this.entry})
+    : super(key: key);
 
   final int position;
   final ChatApp entry;
@@ -81,7 +96,10 @@ class _EntryViewState extends State<_EntryView> with TickerProviderStateMixin {
   void initState() {
     super.initState();
 
-    _controller = AnimationController(duration: Duration(milliseconds: position * 200 + 150), vsync: this);
+    _controller = AnimationController(
+      duration: Duration(milliseconds: position * 200 + 150),
+      vsync: this,
+    );
     _animation = Tween(begin: 0.0, end: 1.0).animate(_controller);
     _controller.forward();
   }
@@ -100,7 +118,10 @@ class _EntryViewState extends State<_EntryView> with TickerProviderStateMixin {
       child: ScaleTransition(
         scale: _animation,
         child: ActionChip(
-          avatar: ImageResolverWidget.icon(uri: entry.icon, color: Colors.white),
+          avatar: ImageResolverWidget.icon(
+            uri: entry.icon,
+            color: Colors.white,
+          ),
           label: Text(context.strings.homeOpenWithButton(entry.name)),
           labelStyle: const TextStyle(color: Colors.white),
           backgroundColor: Color(entry.color.value),

--- a/lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dart
+++ b/lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dart
@@ -37,7 +37,10 @@ class ChatAppNotFoundDialog extends StatelessWidget {
 
   void _openStore(ChatApp app) async {
     try {
-      await launchUrl(app.storeUri, mode: LaunchMode.externalNonBrowserApplication);
+      await launchUrl(
+        app.storeUri,
+        mode: LaunchMode.externalNonBrowserApplication,
+      );
     } catch (e, stackTrace) {
       Log.e(e, stackTrace);
     }
@@ -47,7 +50,8 @@ class ChatAppNotFoundDialog extends StatelessWidget {
 extension _ChatAppExt on ChatApp {
   Uri get storeUri => Platform.isIOS ? appStoreUrl : playStoreUrl;
 
-  Uri get playStoreUrl => Uri.parse('https://play.google.com/store/search?q=$name&c=apps');
+  Uri get playStoreUrl =>
+      Uri.parse('https://play.google.com/store/search?q=$name&c=apps');
 
   Uri get appStoreUrl => Uri.parse('https://www.apple.com/search/$name');
 }

--- a/lib/features/home/home_module.dart
+++ b/lib/features/home/home_module.dart
@@ -7,7 +7,11 @@ import 'top_banner/top_banner_module.dart';
 
 void homeModule() {
   registerFactory<HomeBloc>(
-    () => HomeBloc(phoneFieldComponent: get(), savePhoneNumberHistory: get(), analytics: get()),
+    () => HomeBloc(
+      phoneFieldComponent: get(),
+      savePhoneNumberHistory: get(),
+      analytics: get(),
+    ),
   );
 
   phoneFiledModule();

--- a/lib/features/home/main/home_bloc.dart
+++ b/lib/features/home/main/home_bloc.dart
@@ -17,7 +17,12 @@ import '../chat_apps/chat_apps_mediator.dart';
 import '../phone/phone_field_component.dart';
 import 'home_state.dart';
 
-abstract class HomeMediator implements RegionMediator, ChatAppsMediator, HistoryMediator, CallLogMediator {}
+abstract class HomeMediator
+    implements
+        RegionMediator,
+        ChatAppsMediator,
+        HistoryMediator,
+        CallLogMediator {}
 
 class HomeBloc extends ActionBloc<HomeAction> implements HomeMediator {
   HomeBloc({
@@ -37,18 +42,24 @@ class HomeBloc extends ActionBloc<HomeAction> implements HomeMediator {
     if (phoneNumber != null && phoneNumber.startsWith('tel:')) {
       _analytics.intentHandled('phone_number_received');
 
-      await _phoneFieldComponent.updatePhone(phoneNumber.replaceFirst('tel:', '')).catchError((_) {
-        final obfuscatedNumber = phoneNumber.replaceAll('*', '\\*').replaceAll(RegExp('[0-9]'), '*');
-        Log.e('invalid phone number: $obfuscatedNumber');
-      });
+      await _phoneFieldComponent
+          .updatePhone(phoneNumber.replaceFirst('tel:', ''))
+          .catchError((_) {
+            final obfuscatedNumber = phoneNumber
+                .replaceAll('*', '\\*')
+                .replaceAll(RegExp('[0-9]'), '*');
+            Log.e('invalid phone number: $obfuscatedNumber');
+          });
     }
   }
 
   @override
-  Future<void> onPhoneReceivedFromCallLog(String phoneNumber) => _phoneFieldComponent.updatePhone(phoneNumber);
+  Future<void> onPhoneReceivedFromCallLog(String phoneNumber) =>
+      _phoneFieldComponent.updatePhone(phoneNumber);
 
   @override
-  Future<void> onPhoneReceivedFromHistory(String phoneNumber) => _phoneFieldComponent.updatePhone(phoneNumber);
+  Future<void> onPhoneReceivedFromHistory(String phoneNumber) =>
+      _phoneFieldComponent.updatePhone(phoneNumber);
 
   @override
   void showRegionPicker(RegionCode? selectedCode) {
@@ -58,16 +69,22 @@ class HomeBloc extends ActionBloc<HomeAction> implements HomeMediator {
   }
 
   @override
-  Future<void> onRegionSelected(IRegion region) => _phoneFieldComponent.updateRegion(region);
+  Future<void> onRegionSelected(IRegion region) =>
+      _phoneFieldComponent.updateRegion(region);
 
   @override
   Future<void> launch(String uriTemplate) async {
     try {
       final phoneNumber = await _phoneFieldComponent.getPhoneNumber();
 
-      final uri = uriTemplate.formatWithMap({'phoneNumber': phoneNumber.e164.replaceFirst('+', '')});
+      final uri = uriTemplate.formatWithMap({
+        'phoneNumber': phoneNumber.e164.replaceFirst('+', ''),
+      });
 
-      final successful = await launchUrl(Uri.parse(uri), mode: LaunchMode.externalApplication);
+      final successful = await launchUrl(
+        Uri.parse(uri),
+        mode: LaunchMode.externalApplication,
+      );
 
       if (!successful) {
         throw ChatAppNotFoundError('Failed to launch $uriTemplate');

--- a/lib/features/home/main/home_page.dart
+++ b/lib/features/home/main/home_page.dart
@@ -59,7 +59,8 @@ class _HomePage extends StatefulWidget {
   State<_HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<_HomePage> with ActionMixin<HomeBloc, HomeAction> {
+class _HomePageState extends State<_HomePage>
+    with ActionMixin<HomeBloc, HomeAction> {
   late final _shareService = ShareService();
   final _sub = CompositeSubscription();
 
@@ -89,7 +90,12 @@ class _HomePageState extends State<_HomePage> with ActionMixin<HomeBloc, HomeAct
         actions: [
           PopupMenuButton<String>(
             itemBuilder:
-                (context) => [PopupMenuItem<String>(value: '/settings', child: Text(context.strings.actionSettings))],
+                (context) => [
+                  PopupMenuItem<String>(
+                    value: '/settings',
+                    child: Text(context.strings.actionSettings),
+                  ),
+                ],
             onSelected: (destination) async {
               await Navigator.pushNamed(context, destination);
             },
@@ -110,19 +116,29 @@ class _HomePageState extends State<_HomePage> with ActionMixin<HomeBloc, HomeAct
   }
 
   @override
-  FutureOr<void> handleAction(BuildContext context, HomeAction action) => switch (action) {
-    NavigateToRegionPickerHomeAction(:final current) => _navigateToRegionPicker(context, current),
-  };
+  FutureOr<void> handleAction(BuildContext context, HomeAction action) =>
+      switch (action) {
+        NavigateToRegionPickerHomeAction(:final current) =>
+          _navigateToRegionPicker(context, current),
+      };
 
-  Future<void> _navigateToRegionPicker(BuildContext context, String? regionCode) async {
+  Future<void> _navigateToRegionPicker(
+    BuildContext context,
+    String? regionCode,
+  ) async {
     final bloc = context.read<RegionMediator>();
 
-    final selectedRegion = await Navigator.pushNamed(context, '/regions', arguments: {'selected_code': regionCode});
+    final selectedRegion = await Navigator.pushNamed(
+      context,
+      '/regions',
+      arguments: {'selected_code': regionCode},
+    );
 
     if (selectedRegion is IRegion) {
       await bloc.onRegionSelected(selectedRegion);
     }
   }
 
-  void _handleIntent(Intent intent) => context.read<HomeBloc>().onIntentReceived(intent);
+  void _handleIntent(Intent intent) =>
+      context.read<HomeBloc>().onIntentReceived(intent);
 }

--- a/lib/features/home/main/home_state.dart
+++ b/lib/features/home/main/home_state.dart
@@ -7,5 +7,6 @@ part 'home_state.freezed.dart';
 
 @freezed
 sealed class HomeAction with _$HomeAction implements IAction {
-  factory HomeAction.navigateToRegionPicker(RegionCode? current) = NavigateToRegionPickerHomeAction;
+  factory HomeAction.navigateToRegionPicker(RegionCode? current) =
+      NavigateToRegionPickerHomeAction;
 }

--- a/lib/features/home/phone/phone_field_module.dart
+++ b/lib/features/home/phone/phone_field_module.dart
@@ -7,5 +7,7 @@ void phoneFiledModule() {
 
   registerFactory<PhoneFieldComponent>(() => get<PhoneFieldBloc>());
 
-  registerFactory(() => instance ??= PhoneFieldBloc(get(), getDefaultRegion: get()));
+  registerFactory(
+    () => instance ??= PhoneFieldBloc(get(), getDefaultRegion: get()),
+  );
 }

--- a/lib/features/home/phone/presentation/phone_field_bloc.dart
+++ b/lib/features/home/phone/presentation/phone_field_bloc.dart
@@ -10,10 +10,13 @@ import '../domain/phone_field_error.dart';
 import '../phone_field_component.dart';
 import 'phone_field_state.dart';
 
-class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction> implements PhoneFieldComponent {
-  PhoneFieldBloc(this._plugin, {required GetDefaultRegionUseCase getDefaultRegion})
-    : _getDefaultRegion = getDefaultRegion,
-      super(PhoneFieldState.initial());
+class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction>
+    implements PhoneFieldComponent {
+  PhoneFieldBloc(
+    this._plugin, {
+    required GetDefaultRegionUseCase getDefaultRegion,
+  }) : _getDefaultRegion = getDefaultRegion,
+       super(PhoneFieldState.initial());
 
   final PhoneNumberUtil _plugin;
   final GetDefaultRegionUseCase _getDefaultRegion;
@@ -76,7 +79,9 @@ class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction> 
   Future<void> _updatePhoneField(String phone, IRegion region) async {
     if (phone == _currentText && region == _region) return;
 
-    final formattedPhone = await _plugin.format(phone, region.code).catchError((_) => phone);
+    final formattedPhone = await _plugin
+        .format(phone, region.code)
+        .catchError((_) => phone);
 
     final newValue = _textEditingValueFrom(formattedPhone);
 
@@ -107,10 +112,16 @@ class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction> 
         .catchError((_) => null);
   }
 
-  Future<PhoneNumber> _parsePhoneNumber(String phone, [RegionCode? regionCode]) async {
+  Future<PhoneNumber> _parsePhoneNumber(
+    String phone, [
+    RegionCode? regionCode,
+  ]) async {
     if (phone.isEmpty) throw EmptyPhoneNumberError();
 
-    return await _plugin.parse(phone, regionCode: regionCode).catchError((error, stackTrace) {
+    return await _plugin.parse(phone, regionCode: regionCode).catchError((
+      error,
+      stackTrace,
+    ) {
       // prevent phone number on error logging
       if (error is PlatformException && error.code == 'InvalidNumber') {
         error = InvalidPhoneNumberError();
@@ -133,13 +144,24 @@ class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction> 
   }
 
   TextEditingValue _textEditingValueFrom(String text) {
-    return TextEditingValue(text: text, selection: TextSelection.fromPosition(TextPosition(offset: text.length)));
+    return TextEditingValue(
+      text: text,
+      selection: TextSelection.fromPosition(TextPosition(offset: text.length)),
+    );
   }
 
-  void _emitState({TextEditingController? controller, IRegion? region, Object? error}) {
+  void _emitState({
+    TextEditingController? controller,
+    IRegion? region,
+    Object? error,
+  }) {
     if (error != null) _addClearErrorListener();
 
-    final newState = currentState.copyWith(controller: controller, region: region, error: error);
+    final newState = currentState.copyWith(
+      controller: controller,
+      region: region,
+      error: error,
+    );
 
     setState(newState);
   }

--- a/lib/features/home/phone/presentation/phone_field_error_registry.dart
+++ b/lib/features/home/phone/presentation/phone_field_error_registry.dart
@@ -5,8 +5,13 @@ import '../domain/phone_field_error.dart';
 
 class PhoneFieldErrorConverterRegistry extends ErrorConverterRegistry {
   PhoneFieldErrorConverterRegistry() {
-    on<EmptyPhoneNumberError>((context, _) => MessageFailure(context.strings.homeEmptyPhoneNumberError));
+    on<EmptyPhoneNumberError>(
+      (context, _) => MessageFailure(context.strings.homeEmptyPhoneNumberError),
+    );
 
-    on<InvalidPhoneNumberError>((context, _) => MessageFailure(context.strings.homeInvalidPhoneNumberError));
+    on<InvalidPhoneNumberError>(
+      (context, _) =>
+          MessageFailure(context.strings.homeInvalidPhoneNumberError),
+    );
   }
 }

--- a/lib/features/home/phone/presentation/phone_field_state.dart
+++ b/lib/features/home/phone/presentation/phone_field_state.dart
@@ -12,8 +12,15 @@ class PhoneFieldState extends Equatable implements IState {
 
   factory PhoneFieldState.initial() => PhoneFieldState(TextEditingController());
 
-  PhoneFieldState copyWith({TextEditingController? controller, IRegion? region, Object? error}) =>
-      PhoneFieldState(controller ?? this.controller, region ?? this.region, error);
+  PhoneFieldState copyWith({
+    TextEditingController? controller,
+    IRegion? region,
+    Object? error,
+  }) => PhoneFieldState(
+    controller ?? this.controller,
+    region ?? this.region,
+    error,
+  );
 
   final TextEditingController controller;
   final IRegion? region;

--- a/lib/features/home/phone/presentation/phone_field_widget.dart
+++ b/lib/features/home/phone/presentation/phone_field_widget.dart
@@ -14,7 +14,9 @@ class PhoneFieldWidget extends StatelessWidget
     with StateActionMixin<PhoneFieldBloc, PhoneFieldState, PhoneFieldAction> {
   PhoneFieldWidget({super.key});
 
-  late final _errorMessageAdapter = inject<FailureAdapter>(param1: PhoneFieldErrorConverterRegistry());
+  late final _errorMessageAdapter = inject<FailureAdapter>(
+    param1: PhoneFieldErrorConverterRegistry(),
+  );
 
   late final FocusNode _textFieldFocus = FocusNode();
   final TextStyle _textFieldStyle = const TextStyle(fontSize: 24, height: 1.5);
@@ -41,7 +43,8 @@ class PhoneFieldWidget extends StatelessWidget
           labelText: context.strings.homePhoneNumberLabel,
           // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
           // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
-          errorText: _errorMessageAdapter.maybeAdapt(context, state.error)?.message,
+          errorText:
+              _errorMessageAdapter.maybeAdapt(context, state.error)?.message,
           contentPadding: const EdgeInsets.only(left: 8, right: 8),
           border: const OutlineInputBorder(),
         ),
@@ -52,10 +55,11 @@ class PhoneFieldWidget extends StatelessWidget
   }
 
   @override
-  void handleAction(BuildContext context, PhoneFieldAction action) => switch (action) {
-    HideKeyboardPhoneFieldAction() => dismissKeyboard(),
-    ShowKeyboardPhoneFieldAction() => showKeyboard(),
-  };
+  void handleAction(BuildContext context, PhoneFieldAction action) =>
+      switch (action) {
+        HideKeyboardPhoneFieldAction() => dismissKeyboard(),
+        ShowKeyboardPhoneFieldAction() => showKeyboard(),
+      };
 
   void showKeyboard() => _textFieldFocus.requestFocus();
 

--- a/lib/features/home/top_banner/domain/usecase/app_review.dart
+++ b/lib/features/home/top_banner/domain/usecase/app_review.dart
@@ -6,7 +6,8 @@ import '../../../../../../common/ext/future.dart';
 
 class CanAskForReviewUseCase {
   Future<bool> call() async {
-    final isRequestReviewEnabled = await RemoteConfig.isRequestReviewEnabled.get<bool>();
+    final isRequestReviewEnabled =
+        await RemoteConfig.isRequestReviewEnabled.get<bool>();
 
     if (!isRequestReviewEnabled) {
       return false;

--- a/lib/features/home/top_banner/presentation/top_banner_bloc.dart
+++ b/lib/features/home/top_banner/presentation/top_banner_bloc.dart
@@ -55,7 +55,10 @@ class TopBannerBloc extends StateBloc<TopBannerState> {
   }
 
   TopBannerState _mapToState(TopBannerType type) {
-    _analytics.logEvent('top_banner_viewed', properties: {'banner_type': type.name});
+    _analytics.logEvent(
+      'top_banner_viewed',
+      properties: {'banner_type': type.name},
+    );
     return TopBannerState(type: type);
   }
 }

--- a/lib/features/home/top_banner/presentation/top_banner_widget.dart
+++ b/lib/features/home/top_banner/presentation/top_banner_widget.dart
@@ -9,24 +9,30 @@ import 'top_banner_state.dart';
 
 typedef OnTopBannerActionTap = Function(TopBannerType type);
 
-class TopBannerWidget extends StatelessWidget with StateMixin<TopBannerBloc, TopBannerState> {
+class TopBannerWidget extends StatelessWidget
+    with StateMixin<TopBannerBloc, TopBannerState> {
   TopBannerWidget({Key? key}) : super(key: key);
 
   @override
   late final TopBannerBloc bloc = inject<TopBannerBloc>();
 
   @override
-  Widget buildState(BuildContext context, TopBannerState state) => switch (state) {
-    DisplayTopBannerState(:final type) => _TopBannerView(
-      type: type,
-      onActionTap: (type) => bloc.onTopBannerActionTap(type),
-    ),
-    HiddenTopBannerState() => const SizedBox.shrink(),
-  };
+  Widget buildState(BuildContext context, TopBannerState state) =>
+      switch (state) {
+        DisplayTopBannerState(:final type) => _TopBannerView(
+          type: type,
+          onActionTap: (type) => bloc.onTopBannerActionTap(type),
+        ),
+        HiddenTopBannerState() => const SizedBox.shrink(),
+      };
 }
 
 class _TopBannerView extends StatefulWidget {
-  const _TopBannerView({Key? key, required this.type, required this.onActionTap}) : super(key: key);
+  const _TopBannerView({
+    Key? key,
+    required this.type,
+    required this.onActionTap,
+  }) : super(key: key);
 
   final TopBannerType type;
   final OnTopBannerActionTap onActionTap;
@@ -35,14 +41,18 @@ class _TopBannerView extends StatefulWidget {
   State<_TopBannerView> createState() => _TopBannerViewState();
 }
 
-class _TopBannerViewState extends State<_TopBannerView> with TickerProviderStateMixin {
+class _TopBannerViewState extends State<_TopBannerView>
+    with TickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _animation;
 
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(duration: const Duration(milliseconds: 250), vsync: this);
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 250),
+      vsync: this,
+    );
     // TODO: fix animation
     _animation = Tween(begin: 0.0, end: 1.0).animate(_controller);
     _controller.forward();

--- a/lib/features/home/top_banner/top_banner_module.dart
+++ b/lib/features/home/top_banner/top_banner_module.dart
@@ -4,7 +4,13 @@ import 'domain/usecase/get_top_banner.dart';
 import 'presentation/top_banner_bloc.dart';
 
 void topBannerModule() {
-  registerFactory(() => TopBannerBloc(getTopBanner: get(), setLastAppReviewAtNow: get(), analytics: get()));
+  registerFactory(
+    () => TopBannerBloc(
+      getTopBanner: get(),
+      setLastAppReviewAtNow: get(),
+      analytics: get(),
+    ),
+  );
 
   registerFactory(() => GetTopBannerUseCase(canAskForReview: get()));
 

--- a/lib/features/region/data/repository/region_repository.dart
+++ b/lib/features/region/data/repository/region_repository.dart
@@ -16,19 +16,27 @@ class RegionRepository implements IRegionRepository {
   @override
   Future<List<Country>> getAll() async {
     return _cached ??= (await _plugin.allSupportedRegions())
-      .map((RegionInfo info) => Country(code: info.code, prefix: info.prefix, name: info.name))
+      .map(
+        (RegionInfo info) =>
+            Country(code: info.code, prefix: info.prefix, name: info.name),
+      )
       .toList(growable: false)..sort((a, b) => a.name.compareTo(b.name));
   }
 
   @override
   Future<IRegion> getCurrent() async {
-    final code = await LocalConfig.defaultRegion.get<String?>() ?? await _carrierRegionCode();
+    final code =
+        await LocalConfig.defaultRegion.get<String?>() ??
+        await _carrierRegionCode();
 
     if (code == _defaultRegion.code) return _defaultRegion;
 
     final allRegions = (await getAll()).cast<IRegion>();
 
-    return allRegions.firstWhere((region) => region.code == code, orElse: () => _defaultRegion);
+    return allRegions.firstWhere(
+      (region) => region.code == code,
+      orElse: () => _defaultRegion,
+    );
   }
 
   Future<String> _carrierRegionCode() async {

--- a/lib/features/region/domain/entity/region.dart
+++ b/lib/features/region/domain/entity/region.dart
@@ -26,7 +26,8 @@ abstract class IRegion extends Equatable implements Comparable<IRegion> {
 class Region extends IRegion {
   Region({required this.code, required this.prefix});
 
-  factory Region.defaults() => Region(code: _kDefaultRegionCode, prefix: _kDefaultRegionPrefix);
+  factory Region.defaults() =>
+      Region(code: _kDefaultRegionCode, prefix: _kDefaultRegionPrefix);
 
   @override
   final RegionCode code;

--- a/lib/features/region/domain/usecase/get_default_region.dart
+++ b/lib/features/region/domain/usecase/get_default_region.dart
@@ -5,7 +5,8 @@ import '../repository/region_repository.dart';
 
 @immutable
 class GetDefaultRegionUseCase {
-  const GetDefaultRegionUseCase({required IRegionRepository repository}) : _repository = repository;
+  const GetDefaultRegionUseCase({required IRegionRepository repository})
+    : _repository = repository;
 
   final IRegionRepository _repository;
 

--- a/lib/features/region/domain/usecase/get_regions_by_term.dart
+++ b/lib/features/region/domain/usecase/get_regions_by_term.dart
@@ -5,7 +5,8 @@ import '../repository/region_repository.dart';
 
 @immutable
 class GetRegionsByTermUseCase {
-  const GetRegionsByTermUseCase({required IRegionRepository repository}) : _repository = repository;
+  const GetRegionsByTermUseCase({required IRegionRepository repository})
+    : _repository = repository;
 
   final IRegionRepository _repository;
 

--- a/lib/features/region/domain/usecase/set_detault_region.dart
+++ b/lib/features/region/domain/usecase/set_detault_region.dart
@@ -5,7 +5,8 @@ import '../repository/region_repository.dart';
 
 @immutable
 class SetDefaultRegionUseCase {
-  const SetDefaultRegionUseCase({required IRegionRepository repository}) : _repository = repository;
+  const SetDefaultRegionUseCase({required IRegionRepository repository})
+    : _repository = repository;
 
   final IRegionRepository _repository;
 

--- a/lib/features/region/presentation/region_picker_bloc.dart
+++ b/lib/features/region/presentation/region_picker_bloc.dart
@@ -5,11 +5,18 @@ import '../domain/entity/region.dart';
 import '../domain/usecase/get_regions_by_term.dart';
 import 'region_picker_state.dart';
 
-class RegionPickerBloc extends StateActionBloc<RegionPickerState, RegionPickerAction> {
-  RegionPickerBloc({required GetRegionsByTermUseCase getAvailableRegions, required IAnalytics analytics})
-    : _getAvailableRegions = getAvailableRegions,
-      _analytics = analytics,
-      super(RegionPickerState(countries: List.generate(20, (_) => ShimmerCountry())));
+class RegionPickerBloc
+    extends StateActionBloc<RegionPickerState, RegionPickerAction> {
+  RegionPickerBloc({
+    required GetRegionsByTermUseCase getAvailableRegions,
+    required IAnalytics analytics,
+  }) : _getAvailableRegions = getAvailableRegions,
+       _analytics = analytics,
+       super(
+         RegionPickerState(
+           countries: List.generate(20, (_) => ShimmerCountry()),
+         ),
+       );
 
   final GetRegionsByTermUseCase _getAvailableRegions;
   final IAnalytics _analytics;
@@ -28,7 +35,10 @@ class RegionPickerBloc extends StateActionBloc<RegionPickerState, RegionPickerAc
   void select(Country country) {
     _analytics.itemSelected(
       'region',
-      properties: {'region_selected': country.name, 'region_prefix': country.prefix.toString()},
+      properties: {
+        'region_selected': country.name,
+        'region_prefix': country.prefix.toString(),
+      },
     );
     sendAction(RegionPickerAction.close(country));
   }

--- a/lib/features/region/presentation/region_picker_page.dart
+++ b/lib/features/region/presentation/region_picker_page.dart
@@ -8,7 +8,8 @@ import '../domain/entity/region.dart';
 import 'region_picker_bloc.dart';
 import 'region_picker_state.dart';
 
-typedef _RegionPickerBlocMixin = StateActionMixin<RegionPickerBloc, RegionPickerState, RegionPickerAction>;
+typedef _RegionPickerBlocMixin =
+    StateActionMixin<RegionPickerBloc, RegionPickerState, RegionPickerAction>;
 
 class RegionPicker extends StatelessWidget {
   const RegionPicker({super.key, this.selected});
@@ -20,7 +21,12 @@ class RegionPicker extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(context.strings.availableRegionsTitle)),
       body: DiProvider<RegionPickerBloc>(
-        child: Column(children: [const _SearchView(), Expanded(child: _RegionList(selected: selected))]),
+        child: Column(
+          children: [
+            const _SearchView(),
+            Expanded(child: _RegionList(selected: selected)),
+          ],
+        ),
       ),
     );
   }
@@ -58,7 +64,10 @@ class _SearchViewState extends State<_SearchView> {
         contentPadding: const EdgeInsets.all(16),
         hintText: context.strings.availableRegionsSearch,
         border: const UnderlineInputBorder(),
-        suffixIcon: IconButton(icon: const Icon(Icons.clear), onPressed: ctrl.clear),
+        suffixIcon: IconButton(
+          icon: const Icon(Icons.clear),
+          onPressed: ctrl.clear,
+        ),
       ),
     );
   }
@@ -94,14 +103,21 @@ class _RegionList extends StatelessWidget with _RegionPickerBlocMixin {
   }
 
   @override
-  void handleAction(BuildContext context, RegionPickerAction action) => switch (action) {
+  void handleAction(
+    BuildContext context,
+    RegionPickerAction action,
+  ) => switch (action) {
     CloseRegionPickerAction(:final region) => Navigator.of(context).pop(region),
   };
 }
 
 class _RegionListTile extends StatelessWidget {
-  const _RegionListTile({Key? key, required this.region, required this.onTap, this.isSelected = false})
-    : super(key: key);
+  const _RegionListTile({
+    Key? key,
+    required this.region,
+    required this.onTap,
+    this.isSelected = false,
+  }) : super(key: key);
 
   final Country region;
   final bool isSelected;
@@ -122,11 +138,17 @@ class _RegionListTile extends StatelessWidget {
         children: [
           ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 50),
-            child: Text(region.flag ?? '', style: const TextStyle(fontSize: 28)),
+            child: Text(
+              region.flag ?? '',
+              style: const TextStyle(fontSize: 28),
+            ),
           ),
           Text('${region.name} (${region.code})'),
           const Spacer(),
-          Text('+${region.prefix}', style: const TextStyle(fontWeight: FontWeight.bold)),
+          Text(
+            '+${region.prefix}',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
         ],
       ),
     );

--- a/lib/features/region/presentation/region_picker_state.dart
+++ b/lib/features/region/presentation/region_picker_state.dart
@@ -7,7 +7,8 @@ part 'region_picker_state.freezed.dart';
 
 @freezed
 sealed class RegionPickerState with _$RegionPickerState implements IState {
-  factory RegionPickerState({@Default([]) List<Country> countries}) = LoadedRegionPickerState;
+  factory RegionPickerState({@Default([]) List<Country> countries}) =
+      LoadedRegionPickerState;
 }
 
 @freezed

--- a/lib/features/region/region_module.dart
+++ b/lib/features/region/region_module.dart
@@ -7,7 +7,9 @@ import 'domain/usecase/set_detault_region.dart';
 import 'presentation/region_picker_bloc.dart';
 
 void regionModule() {
-  registerFactory(() => RegionPickerBloc(getAvailableRegions: get(), analytics: get()));
+  registerFactory(
+    () => RegionPickerBloc(getAvailableRegions: get(), analytics: get()),
+  );
 
   registerFactory(() => GetRegionsByTermUseCase(repository: get()));
 

--- a/lib/features/settings/presentation/settings_action.dart
+++ b/lib/features/settings/presentation/settings_action.dart
@@ -5,5 +5,8 @@ part 'settings_action.freezed.dart';
 
 @freezed
 sealed class SettingsAction with _$SettingsAction implements IAction {
-  factory SettingsAction.navigateTo(String route, {@Default(null) Object? args}) = NavigateSettingsAction;
+  factory SettingsAction.navigateTo(
+    String route, {
+    @Default(null) Object? args,
+  }) = NavigateSettingsAction;
 }

--- a/lib/features/settings/presentation/settings_bloc.dart
+++ b/lib/features/settings/presentation/settings_bloc.dart
@@ -8,17 +8,24 @@ import 'settings_action.dart';
 export 'settings_action.dart';
 
 class SettingsBloc extends ActionBloc<SettingsAction> {
-  SettingsBloc({required GetDefaultRegionUseCase getDefaultRegion, required SetDefaultRegionUseCase setDefaultRegion})
-    : _getDefaultRegion = getDefaultRegion,
-      _setDefaultRegion = setDefaultRegion,
-      super();
+  SettingsBloc({
+    required GetDefaultRegionUseCase getDefaultRegion,
+    required SetDefaultRegionUseCase setDefaultRegion,
+  }) : _getDefaultRegion = getDefaultRegion,
+       _setDefaultRegion = setDefaultRegion,
+       super();
 
   final GetDefaultRegionUseCase _getDefaultRegion;
   final SetDefaultRegionUseCase _setDefaultRegion;
 
   void onDefaultRegionOptionClicked() async {
     final defaultRegion = await _getDefaultRegion();
-    sendAction(SettingsAction.navigateTo('/regions', args: {'selected_code': defaultRegion.code}));
+    sendAction(
+      SettingsAction.navigateTo(
+        '/regions',
+        args: {'selected_code': defaultRegion.code},
+      ),
+    );
   }
 
   void onMessagingAppsOptionClicked() {

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -19,7 +19,8 @@ class SettingsPage extends StatelessWidget {
   }
 }
 
-class _SettingsList extends StatelessWidget with ActionMixin<SettingsBloc, SettingsAction> {
+class _SettingsList extends StatelessWidget
+    with ActionMixin<SettingsBloc, SettingsAction> {
   const _SettingsList();
 
   @override
@@ -28,12 +29,14 @@ class _SettingsList extends StatelessWidget with ActionMixin<SettingsBloc, Setti
       _SettingItemTile(
         title: context.strings.settingsRegionTitle,
         subtitle: context.strings.settingsRegionSubtitle,
-        onTap: () => context.read<SettingsBloc>().onDefaultRegionOptionClicked(),
+        onTap:
+            () => context.read<SettingsBloc>().onDefaultRegionOptionClicked(),
       ),
       _SettingItemTile(
         title: context.strings.settingsMessagingAppsTitle,
         subtitle: context.strings.settingsMessagingAppsSubtitle,
-        onTap: () => context.read<SettingsBloc>().onMessagingAppsOptionClicked(),
+        onTap:
+            () => context.read<SettingsBloc>().onMessagingAppsOptionClicked(),
       ),
     ];
 
@@ -45,9 +48,14 @@ class _SettingsList extends StatelessWidget with ActionMixin<SettingsBloc, Setti
   }
 
   @override
-  FutureOr handleAction(BuildContext context, SettingsAction action) => switch (action) {
-    NavigateSettingsAction(:final route, :final args) => _navigateTo(context, route, args),
-  };
+  FutureOr handleAction(BuildContext context, SettingsAction action) =>
+      switch (action) {
+        NavigateSettingsAction(:final route, :final args) => _navigateTo(
+          context,
+          route,
+          args,
+        ),
+      };
 
   Future _navigateTo(BuildContext context, String route, dynamic args) async {
     final bloc = context.read<SettingsBloc>();
@@ -57,7 +65,11 @@ class _SettingsList extends StatelessWidget with ActionMixin<SettingsBloc, Setti
 }
 
 class _SettingItemTile extends StatelessWidget {
-  const _SettingItemTile({required this.title, required this.subtitle, required this.onTap});
+  const _SettingItemTile({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
 
   final String title;
   final String subtitle;

--- a/lib/features/settings/settings_module.dart
+++ b/lib/features/settings/settings_module.dart
@@ -2,5 +2,7 @@ import '../../common/di/definition.dart';
 import 'presentation/settings_bloc.dart';
 
 void settingsModule() {
-  registerFactory(() => SettingsBloc(getDefaultRegion: get(), setDefaultRegion: get()));
+  registerFactory(
+    () => SettingsBloc(getDefaultRegion: get(), setDefaultRegion: get()),
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,10 @@ Future<void> setupApp() async {
   if (kReleaseMode) {
     Logger.root.onRecord.listen(_CrashlyticsTree());
     completer.complete(
-      initAnalytics(amplitudeKey: EnvConfig.amplitudeKey, isEnabled: true).catchError(catchErrorLogger),
+      initAnalytics(
+        amplitudeKey: EnvConfig.amplitudeKey,
+        isEnabled: true,
+      ).catchError(catchErrorLogger),
     );
   }
 
@@ -61,7 +64,11 @@ class _CrashlyticsTree {
     if (!record.isSevere || record.error is NonReportableError) return;
 
     unawaited(
-      crashlytics.recordError(record.error ?? record.message, record.stackTrace, fatal: record.level == Level.SHOUT),
+      crashlytics.recordError(
+        record.error ?? record.message,
+        record.stackTrace,
+        fatal: record.level == Level.SHOUT,
+      ),
     );
   }
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -8,7 +8,10 @@ import 'features/settings/presentation/settings_page.dart';
 
 final routes = <String, RouteBuilder>{
   '/': (settings, _) {
-    return MaterialPageRoute(settings: const RouteSettings(name: 'HomePage'), builder: (_) => const HomePage());
+    return MaterialPageRoute(
+      settings: const RouteSettings(name: 'HomePage'),
+      builder: (_) => const HomePage(),
+    );
   },
   '/regions': (settings, extras) {
     return MaterialPageRoute(
@@ -18,7 +21,10 @@ final routes = <String, RouteBuilder>{
     );
   },
   '/settings': (settings, extras) {
-    return MaterialPageRoute(settings: const RouteSettings(name: 'SettingsPage'), builder: (_) => const SettingsPage());
+    return MaterialPageRoute(
+      settings: const RouteSettings(name: 'SettingsPage'),
+      builder: (_) => const SettingsPage(),
+    );
   },
   '/messaging_apps': (settings, extras) {
     return MaterialPageRoute(
@@ -28,4 +34,5 @@ final routes = <String, RouteBuilder>{
   },
 };
 
-String? _getSelectedCode(dynamic data) => data is Map<String, dynamic> ? data['selected_code'] : null;
+String? _getSelectedCode(dynamic data) =>
+    data is Map<String, dynamic> ? data['selected_code'] : null;

--- a/packages/analytics/lib/src/analytics.dart
+++ b/packages/analytics/lib/src/analytics.dart
@@ -7,7 +7,13 @@ IAnalytics get analytics => _analytics;
 
 late Analytics _analytics;
 
-Future<void> initAnalytics({required String amplitudeKey, required bool isEnabled}) async {
-  _analytics = Analytics([FirebaseAnalyticsWrapper(), AmplitudeAnalyticsWrapper(apiKey: amplitudeKey)]);
+Future<void> initAnalytics({
+  required String amplitudeKey,
+  required bool isEnabled,
+}) async {
+  _analytics = Analytics([
+    FirebaseAnalyticsWrapper(),
+    AmplitudeAnalyticsWrapper(apiKey: amplitudeKey),
+  ]);
   await _analytics.init(isEnabled);
 }

--- a/packages/analytics/lib/src/composite.dart
+++ b/packages/analytics/lib/src/composite.dart
@@ -15,55 +15,90 @@ class Analytics implements IAnalytics {
   }
 
   @override
-  void onAppOpened({Map<String, Object> properties = const {}}) => logEvent('app_opened', properties: properties);
+  void onAppOpened({Map<String, Object> properties = const {}}) =>
+      logEvent('app_opened', properties: properties);
 
   @override
-  void onAppLifecycleChanged(AppLifecycleState state) => logEvent('app_${state.name}');
+  void onAppLifecycleChanged(AppLifecycleState state) =>
+      logEvent('app_${state.name}');
 
   @override
-  void screenViewed(String screenName, {Map<String, Object> properties = const {}}) async {
+  void screenViewed(
+    String screenName, {
+    Map<String, Object> properties = const {},
+  }) async {
     _log('screen_viewed', {'screen_name': screenName, ...properties});
     for (final wrapper in _wrappers) {
-      await wrapper.screenViewed(screenName, properties: properties).catchError(_catchErrorLogger('screen_viewed'));
+      await wrapper
+          .screenViewed(screenName, properties: properties)
+          .catchError(_catchErrorLogger('screen_viewed'));
     }
   }
 
   @override
-  void buttonPressed(String name, {Map<String, Object> properties = const {}}) =>
-      logEvent('button_clicked', properties: {'button_name': name, ...properties});
+  void buttonPressed(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) => logEvent(
+    'button_clicked',
+    properties: {'button_name': name, ...properties},
+  );
 
   @override
   void itemSelected(String name, {Map<String, Object> properties = const {}}) =>
       logEvent('item_selected', properties: {'item_name': name, ...properties});
 
   @override
-  void itemLongPressed(String name, {Map<String, Object> properties = const {}}) =>
-      logEvent('item_long_pressed', properties: {'item_name': name, ...properties});
+  void itemLongPressed(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) => logEvent(
+    'item_long_pressed',
+    properties: {'item_name': name, ...properties},
+  );
 
   @override
   void itemRemoved(String name, {Map<String, Object> properties = const {}}) =>
       logEvent('item_removed', properties: {'item_name': name, ...properties});
 
   @override
-  void intentHandled(String name, {Map<String, Object> properties = const {}}) =>
-      logEvent('intent_handled', properties: {'intent_name': name, ...properties});
+  void intentHandled(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) => logEvent(
+    'intent_handled',
+    properties: {'intent_name': name, ...properties},
+  );
 
   @override
-  void logEvent(String name, {Map<String, Object> properties = const {}}) async {
+  void logEvent(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) async {
     _log(name, properties);
     for (final wrapper in _wrappers) {
-      await wrapper.logEvent(name, properties: properties).catchError(_catchErrorLogger(name));
+      await wrapper
+          .logEvent(name, properties: properties)
+          .catchError(_catchErrorLogger(name));
     }
   }
 
   void _log(String event, Map<String, Object> properties) {
-    _logger.info({'event_name': event, 'properties': properties}, null, Trace.current(3));
+    _logger.info(
+      {'event_name': event, 'properties': properties},
+      null,
+      Trace.current(3),
+    );
   }
 
   dynamic _catchErrorLogger(event) {
     final callerTrace = Trace.current(1);
     return (Object error, [StackTrace? trace]) {
-      _logger.warning('Error while logging event: $event', error, trace ?? callerTrace);
+      _logger.warning(
+        'Error while logging event: $event',
+        error,
+        trace ?? callerTrace,
+      );
     };
   }
 }

--- a/packages/analytics/lib/src/impl/amplitude.dart
+++ b/packages/analytics/lib/src/impl/amplitude.dart
@@ -21,10 +21,18 @@ class AmplitudeAnalyticsWrapper extends AnalyticsWrapper {
   }
 
   @override
-  Future<void> screenViewed(String screenName, {Map<String, Object> properties = const {}}) =>
-      logEvent('screen_viewed', properties: {'screen_name': screenName, ...properties});
+  Future<void> screenViewed(
+    String screenName, {
+    Map<String, Object> properties = const {},
+  }) => logEvent(
+    'screen_viewed',
+    properties: {'screen_name': screenName, ...properties},
+  );
 
   @override
-  Future<void> logEvent(String name, {Map<String, Object> properties = const {}}) async =>
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) async =>
       await _amplitude?.track(BaseEvent(name, eventProperties: properties));
 }

--- a/packages/analytics/lib/src/impl/firebase.dart
+++ b/packages/analytics/lib/src/impl/firebase.dart
@@ -6,13 +6,18 @@ class FirebaseAnalyticsWrapper extends AnalyticsWrapper {
   late final FirebaseAnalytics _firebase = FirebaseAnalytics.instance;
 
   @override
-  Future<void> init(bool isEnabled) => _firebase.setAnalyticsCollectionEnabled(isEnabled);
+  Future<void> init(bool isEnabled) =>
+      _firebase.setAnalyticsCollectionEnabled(isEnabled);
 
   @override
-  Future<void> screenViewed(String screenName, {Map<String, Object> properties = const {}}) =>
-      _firebase.logScreenView(screenName: screenName);
+  Future<void> screenViewed(
+    String screenName, {
+    Map<String, Object> properties = const {},
+  }) => _firebase.logScreenView(screenName: screenName);
 
   @override
-  Future<void> logEvent(String name, {Map<String, Object> properties = const {}}) =>
-      _firebase.logEvent(name: name, parameters: properties);
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) => _firebase.logEvent(name: name, parameters: properties);
 }

--- a/packages/analytics/lib/src/route_observer.dart
+++ b/packages/analytics/lib/src/route_observer.dart
@@ -48,7 +48,9 @@ class AnalyticsRouteObserver extends RouteObserver<ModalRoute<dynamic>> {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPop(route, previousRoute);
-    if (previousRoute != null && routeFilter(previousRoute) && routeFilter(route)) {
+    if (previousRoute != null &&
+        routeFilter(previousRoute) &&
+        routeFilter(route)) {
       _sendScreenView(previousRoute);
     }
   }

--- a/packages/analytics/lib/src/wrapper.dart
+++ b/packages/analytics/lib/src/wrapper.dart
@@ -3,13 +3,22 @@ import 'package:flutter/widgets.dart';
 abstract class AnalyticsWrapper {
   Future<void> init(bool isEnabled);
 
-  Future<void> screenViewed(String screenName, {Map<String, Object> properties = const {}});
+  Future<void> screenViewed(
+    String screenName, {
+    Map<String, Object> properties = const {},
+  });
 
-  Future<void> logEvent(String name, {Map<String, Object> properties = const {}});
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object> properties = const {},
+  });
 }
 
 abstract class IAnalytics {
-  void screenViewed(String screenName, {Map<String, Object> properties = const {}});
+  void screenViewed(
+    String screenName, {
+    Map<String, Object> properties = const {},
+  });
 
   void onAppOpened({Map<String, Object> properties = const {}});
 
@@ -19,7 +28,10 @@ abstract class IAnalytics {
 
   void itemSelected(String name, {Map<String, Object> properties = const {}});
 
-  void itemLongPressed(String name, {Map<String, Object> properties = const {}});
+  void itemLongPressed(
+    String name, {
+    Map<String, Object> properties = const {},
+  });
 
   void itemRemoved(String name, {Map<String, Object> properties = const {}});
 

--- a/packages/config_manager/core/lib/src/enum_mixin.dart
+++ b/packages/config_manager/core/lib/src/enum_mixin.dart
@@ -14,7 +14,8 @@ mixin KeyValueMixin<Storage extends KeyValueStorage> {
   }
 }
 
-mixin KeyValueWritableMixin<Storage extends KeyValueWritableStorage> on KeyValueMixin<Storage> {
+mixin KeyValueWritableMixin<Storage extends KeyValueWritableStorage>
+    on KeyValueMixin<Storage> {
   Future<void> set<T extends Object>(T value) async {
     final storage = await this.storage;
     await storage.setValue(key, value);

--- a/packages/config_manager/core/lib/src/impl/preferences_storage.dart
+++ b/packages/config_manager/core/lib/src/impl/preferences_storage.dart
@@ -3,9 +3,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../config_core.dart';
 
 class PreferencesConfigStorage implements ILocalConfigStorage {
-  PreferencesConfigStorage({required SharedPreferences prefs, Map<String, dynamic> localConfigDefaults = const {}})
-    : _prefs = prefs,
-      _defaults = localConfigDefaults;
+  PreferencesConfigStorage({
+    required SharedPreferences prefs,
+    Map<String, dynamic> localConfigDefaults = const {},
+  }) : _prefs = prefs,
+       _defaults = localConfigDefaults;
 
   final SharedPreferences _prefs;
   final Map<String, dynamic> _defaults;
@@ -19,7 +21,8 @@ class PreferencesConfigStorage implements ILocalConfigStorage {
   }
 
   @override
-  Future setValue<T extends Object>(String key, T value) => _setValue(value, key).then((_) => _prefs.reload());
+  Future setValue<T extends Object>(String key, T value) =>
+      _setValue(value, key).then((_) => _prefs.reload());
 
   Future<bool> _setValue(value, String key) async {
     if (value is int) {

--- a/packages/config_manager/firebase/lib/src/firebase_storage.dart
+++ b/packages/config_manager/firebase/lib/src/firebase_storage.dart
@@ -2,7 +2,8 @@ import 'package:config_core/config_core.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 
 class FirebaseConfigStorage implements IRemoteConfigStorage {
-  FirebaseConfigStorage({required FirebaseRemoteConfig remoteConfig}) : _remoteConfig = remoteConfig;
+  FirebaseConfigStorage({required FirebaseRemoteConfig remoteConfig})
+    : _remoteConfig = remoteConfig;
 
   final FirebaseRemoteConfig _remoteConfig;
 

--- a/test/features/region/data/repository/region_repository_test.dart
+++ b/test/features/region/data/repository/region_repository_test.dart
@@ -29,11 +29,14 @@ void main() {
     RegionInfo(name: 'Colombia', code: 'CO', prefix: 57),
   ];
 
-  final countries = regions.map((e) => Country(code: e.code, prefix: e.prefix, name: e.name)).toList(growable: false)
-    ..sort((a, b) => a.name.compareTo(b.name));
+  final countries = regions
+    .map((e) => Country(code: e.code, prefix: e.prefix, name: e.name))
+    .toList(growable: false)..sort((a, b) => a.name.compareTo(b.name));
 
   setUpAll(() {
-    GetIt.instance.registerFactoryAsync<ILocalConfigStorage>(() async => mockLocalConfigStorage);
+    GetIt.instance.registerFactoryAsync<ILocalConfigStorage>(
+      () async => mockLocalConfigStorage,
+    );
   });
 
   setUp(() {
@@ -41,12 +44,18 @@ void main() {
     mockLocalConfigStorage = MockLocalConfigStorage();
     regionRepository = RegionRepository(plugin: mockPhoneNumberUtil);
 
-    when(() => mockLocalConfigStorage.getValue<String?>(LocalConfig.defaultRegion.key)).thenReturn(null);
+    when(
+      () => mockLocalConfigStorage.getValue<String?>(
+        LocalConfig.defaultRegion.key,
+      ),
+    ).thenReturn(null);
   });
 
   test('getAll returns list of countries sorted by name', () async {
     // arrange
-    when(() => mockPhoneNumberUtil.allSupportedRegions()).thenAnswer((_) async => regions);
+    when(
+      () => mockPhoneNumberUtil.allSupportedRegions(),
+    ).thenAnswer((_) async => regions);
 
     // act
     final result = await regionRepository.getAll();
@@ -55,24 +64,35 @@ void main() {
     expect(result, equals(countries));
   });
 
-  test('getCurrent returns default region if carrier region code is invalid', () async {
-    // arrange
-    when(() => mockPhoneNumberUtil.carrierRegionCode()).thenAnswer((_) async => 'invalid code');
+  test(
+    'getCurrent returns default region if carrier region code is invalid',
+    () async {
+      // arrange
+      when(
+        () => mockPhoneNumberUtil.carrierRegionCode(),
+      ).thenAnswer((_) async => 'invalid code');
 
-    when(() => mockPhoneNumberUtil.allSupportedRegions()).thenAnswer((_) async => regions);
+      when(
+        () => mockPhoneNumberUtil.allSupportedRegions(),
+      ).thenAnswer((_) async => regions);
 
-    // act
-    final result = await regionRepository.getCurrent();
+      // act
+      final result = await regionRepository.getCurrent();
 
-    // assert
-    expect(result, equals(defaultRegion));
-  });
+      // assert
+      expect(result, equals(defaultRegion));
+    },
+  );
 
   test('getCurrent returns correct region for carrier region code', () async {
     // arrange
-    when(() => mockPhoneNumberUtil.carrierRegionCode()).thenAnswer((_) async => 'MX');
+    when(
+      () => mockPhoneNumberUtil.carrierRegionCode(),
+    ).thenAnswer((_) async => 'MX');
 
-    when(() => mockPhoneNumberUtil.allSupportedRegions()).thenAnswer((_) async => regions);
+    when(
+      () => mockPhoneNumberUtil.allSupportedRegions(),
+    ).thenAnswer((_) async => regions);
 
     // act
     final result = await regionRepository.getCurrent();
@@ -81,24 +101,33 @@ void main() {
     expect(result, equals(countries[6]));
   });
 
-  test('getCurrent should return default region when carrierRegionCode fails', () async {
-    // arrange
-    when(
-      () => mockPhoneNumberUtil.carrierRegionCode(),
-    ).thenAnswer((_) async => throw 'Failed to get carrier region code');
+  test(
+    'getCurrent should return default region when carrierRegionCode fails',
+    () async {
+      // arrange
+      when(
+        () => mockPhoneNumberUtil.carrierRegionCode(),
+      ).thenAnswer((_) async => throw 'Failed to get carrier region code');
 
-    // act
-    final result = await regionRepository.getCurrent();
+      // act
+      final result = await regionRepository.getCurrent();
 
-    // assert
-    expect(result, equals(defaultRegion));
-  });
+      // assert
+      expect(result, equals(defaultRegion));
+    },
+  );
 
   test('getCurrent should return stored region when exists', () async {
     // arrange
-    when(() => mockLocalConfigStorage.getValue<String?>(LocalConfig.defaultRegion.key)).thenReturn('CO');
+    when(
+      () => mockLocalConfigStorage.getValue<String?>(
+        LocalConfig.defaultRegion.key,
+      ),
+    ).thenReturn('CO');
 
-    when(() => mockPhoneNumberUtil.allSupportedRegions()).thenAnswer((_) async => regions);
+    when(
+      () => mockPhoneNumberUtil.allSupportedRegions(),
+    ).thenAnswer((_) async => regions);
 
     // act
     final result = await regionRepository.getCurrent();
@@ -109,12 +138,22 @@ void main() {
 
   test('setCurrent should store region code', () async {
     // arrange
-    when(() => mockLocalConfigStorage.setValue(LocalConfig.defaultRegion.key, any<String>())).thenAnswer((_) async {});
+    when(
+      () => mockLocalConfigStorage.setValue(
+        LocalConfig.defaultRegion.key,
+        any<String>(),
+      ),
+    ).thenAnswer((_) async {});
 
     // act
     await regionRepository.setCurrent(countries[3]);
 
     // assert
-    verify(() => mockLocalConfigStorage.setValue(LocalConfig.defaultRegion.key, countries[3].code)).called(1);
+    verify(
+      () => mockLocalConfigStorage.setValue(
+        LocalConfig.defaultRegion.key,
+        countries[3].code,
+      ),
+    ).called(1);
   });
 }

--- a/test/features/region/presentation/region_picker_bloc_test.dart
+++ b/test/features/region/presentation/region_picker_bloc_test.dart
@@ -6,7 +6,8 @@ import 'package:zapify/features/region/domain/usecase/get_regions_by_term.dart';
 import 'package:zapify/features/region/presentation/region_picker_bloc.dart';
 import 'package:zapify/features/region/presentation/region_picker_state.dart';
 
-class MockGetRegionsByTermUseCase extends Mock implements GetRegionsByTermUseCase {}
+class MockGetRegionsByTermUseCase extends Mock
+    implements GetRegionsByTermUseCase {}
 
 class MockAnalytics extends Mock implements IAnalytics {}
 
@@ -28,19 +29,32 @@ void main() {
     mockGetRegionsByTermUseCase = MockGetRegionsByTermUseCase();
     mockAnalytics = MockAnalytics();
 
-    regionPickerBloc = RegionPickerBloc(getAvailableRegions: mockGetRegionsByTermUseCase, analytics: mockAnalytics);
+    regionPickerBloc = RegionPickerBloc(
+      getAvailableRegions: mockGetRegionsByTermUseCase,
+      analytics: mockAnalytics,
+    );
 
-    when(() => mockGetRegionsByTermUseCase(term: term)).thenAnswer((_) async => [brazil]);
+    when(
+      () => mockGetRegionsByTermUseCase(term: term),
+    ).thenAnswer((_) async => [brazil]);
 
-    when(() => mockGetRegionsByTermUseCase()).thenAnswer((_) async => countries);
+    when(
+      () => mockGetRegionsByTermUseCase(),
+    ).thenAnswer((_) async => countries);
   });
 
   test('initial state should be RegionPickerState.initial()', () {
-    expect(regionPickerBloc.currentState, RegionPickerState(countries: List.generate(20, (_) => ShimmerCountry())));
+    expect(
+      regionPickerBloc.currentState,
+      RegionPickerState(countries: List.generate(20, (_) => ShimmerCountry())),
+    );
   });
 
   test('state should be RegionPickerState() when load', () {
-    expectLater(regionPickerBloc.stream, emits(RegionPickerState(countries: countries)));
+    expectLater(
+      regionPickerBloc.stream,
+      emits(RegionPickerState(countries: countries)),
+    );
   });
 
   group('fetchRegionsByTerm', () {
@@ -50,34 +64,55 @@ void main() {
       verify(() => mockGetRegionsByTermUseCase(term: term)).called(1);
     });
 
-    test('should update state with countries filtered by term "$term"', () async {
-      regionPickerBloc.fetchRegionsByTerm(term);
+    test(
+      'should update state with countries filtered by term "$term"',
+      () async {
+        regionPickerBloc.fetchRegionsByTerm(term);
 
-      expect(regionPickerBloc.stream, emits(RegionPickerState(countries: [brazil])));
-    });
+        expect(
+          regionPickerBloc.stream,
+          emits(RegionPickerState(countries: [brazil])),
+        );
+      },
+    );
   });
 
   group('select', () {
     final country = brazil;
 
-    test('should call analytics.itemSelected with the selected country properties', () async {
-      regionPickerBloc.select(country);
+    test(
+      'should call analytics.itemSelected with the selected country properties',
+      () async {
+        regionPickerBloc.select(country);
 
-      verify(
-        () => mockAnalytics.itemSelected('region', properties: {'region_selected': 'Brazil', 'region_prefix': '55'}),
-      ).called(1);
-    });
+        verify(
+          () => mockAnalytics.itemSelected(
+            'region',
+            properties: {'region_selected': 'Brazil', 'region_prefix': '55'},
+          ),
+        ).called(1);
+      },
+    );
 
-    test('should send a RegionPickerAction.close action with the selected country', () async {
-      expectLater(regionPickerBloc.stream, emits(RegionPickerAction.close(brazil)));
+    test(
+      'should send a RegionPickerAction.close action with the selected country',
+      () async {
+        expectLater(
+          regionPickerBloc.stream,
+          emits(RegionPickerAction.close(brazil)),
+        );
 
-      regionPickerBloc.select(country);
-    });
+        regionPickerBloc.select(country);
+      },
+    );
   });
 
-  test('dismiss should send a RegionPickerAction.close action without a country', () {
-    expectLater(regionPickerBloc.stream, emits(RegionPickerAction.close()));
+  test(
+    'dismiss should send a RegionPickerAction.close action without a country',
+    () {
+      expectLater(regionPickerBloc.stream, emits(RegionPickerAction.close()));
 
-    regionPickerBloc.dismiss();
-  });
+      regionPickerBloc.dismiss();
+    },
+  );
 }


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files, focusing on code formatting, workflow enhancements, and minor refactoring for better readability and maintainability. The most important changes include adding a new code formatting check in the GitHub Actions workflow, adjusting the code formatting width, and refactoring various Dart files for improved readability.

Workflow Enhancements:
* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R1): Added a new job `check-format` to the workflow to check code formatting on affected files. This job includes steps for checking out the repository, setting up the Flutter SDK, caching pub packages, and filtering Dart files to check. [[1]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R1) [[2]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L12-R14) [[3]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R65-R123)

Code Formatting:
* [`analysis_options.yaml`](diffhunk://#diff-9a967a7bb0393381dfdf9cce102a9cea39146829ab8b38e983d54ac8827486bcL13-R13): Changed the `page_width` for the Dart formatter from 120 to 80 to enforce a narrower code style.

Refactoring for Readability:
* Various Dart files (`lib/app.dart`, `lib/common/advertising/ad_list_view_separator.dart`, `lib/common/common_module.dart`, `lib/common/config/env_config.dart`, `lib/common/config/local_config.dart`, `lib/common/di/definition.dart`, `lib/common/di/inject.dart`, `lib/common/di/provider.dart`, `lib/common/ext/future.dart`, `lib/common/resources/localizations.dart`, `lib/common/resources/theme.dart`, `lib/common/services/firebase.dart`, `lib/common/services/share_service.dart`, `lib/common/widgets/feedback_view.dart`): Refactored code to improve readability by breaking long lines, adding line breaks, and reformatting parameter lists. [[1]](diffhunk://#diff-1fb04a3749d56cc322a1bc7e7e6b8988600930c339b0d8df7119837e1b7ae20dL20-R22) [[2]](diffhunk://#diff-39316e2fc02afd4a08b5af5a8786fcb104a7ff976dd105195d35cb4f211ff9d9L16-R32) [[3]](diffhunk://#diff-39316e2fc02afd4a08b5af5a8786fcb104a7ff976dd105195d35cb4f211ff9d9L87-R97) [[4]](diffhunk://#diff-39316e2fc02afd4a08b5af5a8786fcb104a7ff976dd105195d35cb4f211ff9d9L96-R107) [[5]](diffhunk://#diff-39316e2fc02afd4a08b5af5a8786fcb104a7ff976dd105195d35cb4f211ff9d9L136-R150) [[6]](diffhunk://#diff-6490c63d4bd25d3e0ee696979da089811fbdd19f32962687e48a578756c090a1L33-R61) [[7]](diffhunk://#diff-af45697942baed1c94433a5de47565646696cf1dfaf17f7a894a912a4c82bfbcL3-R32) [[8]](diffhunk://#diff-f72f3e626f6740ba843b4201eb0f93429ef502b50a5d8e254c624981ac4acec8L7-R10) [[9]](diffhunk://#diff-f72f3e626f6740ba843b4201eb0f93429ef502b50a5d8e254c624981ac4acec8L19-R24) [[10]](diffhunk://#diff-e28013d817ae2e2e3650749166afa6e36373111677d59dde00406b389cf09447L22-R26) [[11]](diffhunk://#diff-d09ce59dbb741c10686827cf40b1c5930a8d01a646b8bf9f18955492827d1a48L6-R7) [[12]](diffhunk://#diff-d09ce59dbb741c10686827cf40b1c5930a8d01a646b8bf9f18955492827d1a48L15-R17) [[13]](diffhunk://#diff-ebf2287c5806c404aac921e9fd09413d38f4523810e611d189f744bc93e2cbadL8-R9) [[14]](diffhunk://#diff-7d94652d668abd42494ed324fd5097dac0a44a5f62475b76815e104f0d25562aL7-R11) [[15]](diffhunk://#diff-e842c45c673690aa1ea92d0360a0c9aeaf6c8a0bfa0fc86acf26678087e60d37L8-R9) [[16]](diffhunk://#diff-e842c45c673690aa1ea92d0360a0c9aeaf6c8a0bfa0fc86acf26678087e60d37L17-R20) [[17]](diffhunk://#diff-b2885554b407579aaefb30fb0e2d85934403c158ad5cdc5e3bbd2ae9335cf14aL19-R22) [[18]](diffhunk://#diff-b0ebeba01851a8f3d5531bad7bce7ccdb2885f6ab58fec749d536dfe216595cbL12-R14) [[19]](diffhunk://#diff-b0ebeba01851a8f3d5531bad7bce7ccdb2885f6ab58fec749d536dfe216595cbL26-R31) [[20]](diffhunk://#diff-e9dd46ba8e4924f1280ab527d7536b46330e4d717d7e7c513112f10f5f65458cL16-R18) [[21]](diffhunk://#diff-d93a4727807f26ff7366b0732e5d60590a9c940f434af77098fb34ba7a2e9652L26-R36) [[22]](diffhunk://#diff-d93a4727807f26ff7366b0732e5d60590a9c940f434af77098fb34ba7a2e9652L40-R63)
