### PR TITLE
Add translations for Spanish and some other intl adjustments

### DIFF
--- a/lib/common/common_module.dart
+++ b/lib/common/common_module.dart
@@ -22,8 +22,8 @@ void commonModule() {
       registry: registry,
       fallback:
           (context, _) => ErrorFeedback(
-            message: context.strings.unknowErrorMessage,
-            primaryButtonText: context.strings.unknowErrorAction,
+            message: context.strings.unknownErrorMessage,
+            primaryButtonText: context.strings.unknownErrorAction,
           ),
     ),
   );

--- a/lib/common/resources/l10n/app_en.arb
+++ b/lib/common/resources/l10n/app_en.arb
@@ -25,8 +25,8 @@
     "actionSettings": "Settings",
 
     "callLogTabTitle": "Phone calls",
-    "callLogPermissionMessage": "You need to give permission to display call log.",
-    "callLogPermissionButtonLabel": "Give permission",
+    "callLogPermissionMessage": "To access your call history and make messaging easier, we need your permission. Rest assured, no information is stored or shared.",
+    "callLogPermissionButtonLabel": "Grant permission",
     "callLogEmptyMessage": "No calls to display",
 
     "availableRegionsTitle": "Select a country",

--- a/lib/common/resources/l10n/app_en.arb
+++ b/lib/common/resources/l10n/app_en.arb
@@ -1,6 +1,6 @@
 {
-    "unknowErrorMessage": "Oops! Something went wrong!",
-    "unknowErrorAction": "Try again",
+    "unknownErrorMessage": "Oops! Something went wrong!",
+    "unknownErrorAction": "Try again",
 
     "advertisementPlaceholder": "Advertisement",
 

--- a/lib/common/resources/l10n/app_es.arb
+++ b/lib/common/resources/l10n/app_es.arb
@@ -1,0 +1,50 @@
+{
+  "unknownErrorMessage": "¡Ups! ¡Algo salió mal!",
+  "unknownErrorAction": "Inténtalo de nuevo",
+
+  "advertisementPlaceholder": "Publicidad",
+
+  "homeTopBannerAskToReviewContent": "¿Te gusta Zapify? Cuéntanos.",
+  "homeTopBannerAskToReviewButton": "OPINAR",
+
+  "homePhoneNumberLabel": "Número de teléfono",
+  "homeOpenWithButton": "{appName}",
+  "homeEmptyPhoneNumberError": "Por favor, introduce el número de teléfono",
+  "homeInvalidPhoneNumberError": "Número de teléfono no válido",
+
+  "homeChatAppNotFoundErrorTitle": "¡Ups!",
+  "homeChatAppNotFoundErrorMessage": "Ocurrió un error al abrir \"{appName}\".",
+  "homeChatAppNotFoundErrorPrimaryAction": "Buscar en la tienda",
+  "homeChatAppNotFoundErrorSecondaryAction": "Cancelar",
+
+  "recentNumbersTitle": "Números recientes",
+  "recentNumbersEmpty": "Aún no hay números recientes",
+  "recentNumberRemoved": "¡El número reciente \"{phoneNumber}\" fue eliminado!",
+  "actionRemove": "Eliminar",
+  "actionUndo": "Deshacer",
+  "actionSettings": "Ajustes",
+
+  "callLogTabTitle": "Llamadas",
+  "callLogPermissionMessage": "Para acceder a tu historial de llamadas y facilitar la mensajería, necesitamos tu permiso. No te preocupes, no se almacena ni comparte ninguna información.",
+  "callLogPermissionButtonLabel": "Conceder permiso",
+  "callLogEmptyMessage": "No hay llamadas para mostrar",
+
+  "availableRegionsTitle": "Selecciona un país",
+  "availableRegionsSearch": "Buscar…",
+
+  "settingsTitle": "Ajustes",
+  "settingsRegionTitle": "Región predeterminada",
+  "settingsRegionSubtitle": "Selecciona la región predeterminada para abrir un número",
+  "settingsMessagingAppsTitle": "Aplicaciones de mensajería",
+  "settingsMessagingAppsSubtitle": "Selecciona las aplicaciones de mensajería que deseas usar",
+
+  "messagingAppsTitle": "Aplicaciones de mensajería",
+  "messagingAppsEnabledHeader": "Aplicaciones disponibles",
+  "messagingAppsDisabledHeader": "Aplicaciones ocultas",
+
+  "today": "'Hoy a las' H:mm",
+  "yesterday": "'Ayer a las' H:mm",
+  "lastCoupleOfDays": "EEEE 'a las' H:mm",
+  "lastCoupleOfMonths": "d 'de' MMMM 'a las' H:mm",
+  "longTimeAgo": "d 'de' MMMM, yyyy"
+}

--- a/lib/common/resources/l10n/app_pt.arb
+++ b/lib/common/resources/l10n/app_pt.arb
@@ -1,6 +1,6 @@
 {
-    "unknowErrorMessage": "Oops! Ocorreu um erro inesperado!",
-    "unknowErrorAction": "Tentar novamente",
+    "unknownErrorMessage": "Oops! Ocorreu um erro inesperado!",
+    "unknownErrorAction": "Tentar novamente",
 
     "advertisementPlaceholder": "Publicidade",
 

--- a/lib/common/resources/l10n/app_pt.arb
+++ b/lib/common/resources/l10n/app_pt.arb
@@ -25,8 +25,8 @@
     "actionSettings": "Configurações",
 
     "callLogTabTitle": "Chamadas",
-    "callLogPermissionMessage": "Para exibir o histórico de chamadas, é necessário permitir o acesso.",
-    "callLogPermissionButtonLabel": "Permitir",
+    "callLogPermissionMessage": "Para acessar seu histórico de chamadas e facilitar o envio de mensagens, precisamos da sua permissão. Saiba que nenhuma informação é armazenada ou compartilhada.",
+    "callLogPermissionButtonLabel": "Conceder permissão",
     "callLogEmptyMessage": "Nenhuma chamada para exibir",
 
     "availableRegionsTitle": "Selecione o país",

--- a/lib/common/resources/l10n/generated/app_localizations.dart
+++ b/lib/common/resources/l10n/generated/app_localizations.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
 import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
 import 'app_localizations_pt.dart';
 
 // ignore_for_file: type=lint
@@ -92,6 +93,7 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
+    Locale('es'),
     Locale('pt')
   ];
 
@@ -333,7 +335,7 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'pt'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'es', 'pt'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -345,6 +347,7 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
     case 'pt': return AppLocalizationsPt();
   }
 

--- a/lib/common/resources/l10n/generated/app_localizations.dart
+++ b/lib/common/resources/l10n/generated/app_localizations.dart
@@ -218,13 +218,13 @@ abstract class AppLocalizations {
   /// No description provided for @callLogPermissionMessage.
   ///
   /// In en, this message translates to:
-  /// **'You need to give permission to display call log.'**
+  /// **'To access your call history and make messaging easier, we need your permission. Rest assured, no information is stored or shared.'**
   String get callLogPermissionMessage;
 
   /// No description provided for @callLogPermissionButtonLabel.
   ///
   /// In en, this message translates to:
-  /// **'Give permission'**
+  /// **'Grant permission'**
   String get callLogPermissionButtonLabel;
 
   /// No description provided for @callLogEmptyMessage.

--- a/lib/common/resources/l10n/generated/app_localizations.dart
+++ b/lib/common/resources/l10n/generated/app_localizations.dart
@@ -95,17 +95,17 @@ abstract class AppLocalizations {
     Locale('pt')
   ];
 
-  /// No description provided for @unknowErrorMessage.
+  /// No description provided for @unknownErrorMessage.
   ///
   /// In en, this message translates to:
   /// **'Oops! Something went wrong!'**
-  String get unknowErrorMessage;
+  String get unknownErrorMessage;
 
-  /// No description provided for @unknowErrorAction.
+  /// No description provided for @unknownErrorAction.
   ///
   /// In en, this message translates to:
   /// **'Try again'**
-  String get unknowErrorAction;
+  String get unknownErrorAction;
 
   /// No description provided for @advertisementPlaceholder.
   ///

--- a/lib/common/resources/l10n/generated/app_localizations_en.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_en.dart
@@ -9,10 +9,10 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get unknowErrorMessage => 'Oops! Something went wrong!';
+  String get unknownErrorMessage => 'Oops! Something went wrong!';
 
   @override
-  String get unknowErrorAction => 'Try again';
+  String get unknownErrorAction => 'Try again';
 
   @override
   String get advertisementPlaceholder => 'Advertisement';

--- a/lib/common/resources/l10n/generated/app_localizations_en.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_en.dart
@@ -75,10 +75,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get callLogTabTitle => 'Phone calls';
 
   @override
-  String get callLogPermissionMessage => 'You need to give permission to display call log.';
+  String get callLogPermissionMessage => 'To access your call history and make messaging easier, we need your permission. Rest assured, no information is stored or shared.';
 
   @override
-  String get callLogPermissionButtonLabel => 'Give permission';
+  String get callLogPermissionButtonLabel => 'Grant permission';
 
   @override
   String get callLogEmptyMessage => 'No calls to display';

--- a/lib/common/resources/l10n/generated/app_localizations_es.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_es.dart
@@ -1,0 +1,130 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Spanish Castilian (`es`).
+class AppLocalizationsEs extends AppLocalizations {
+  AppLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get unknownErrorMessage => '¡Ups! ¡Algo salió mal!';
+
+  @override
+  String get unknownErrorAction => 'Inténtalo de nuevo';
+
+  @override
+  String get advertisementPlaceholder => 'Publicidad';
+
+  @override
+  String get homeTopBannerAskToReviewContent => '¿Te gusta Zapify? Cuéntanos.';
+
+  @override
+  String get homeTopBannerAskToReviewButton => 'OPINAR';
+
+  @override
+  String get homePhoneNumberLabel => 'Número de teléfono';
+
+  @override
+  String homeOpenWithButton(Object appName) {
+    return '$appName';
+  }
+
+  @override
+  String get homeEmptyPhoneNumberError => 'Por favor, introduce el número de teléfono';
+
+  @override
+  String get homeInvalidPhoneNumberError => 'Número de teléfono no válido';
+
+  @override
+  String get homeChatAppNotFoundErrorTitle => '¡Ups!';
+
+  @override
+  String homeChatAppNotFoundErrorMessage(Object appName) {
+    return 'Ocurrió un error al abrir \"$appName\".';
+  }
+
+  @override
+  String get homeChatAppNotFoundErrorPrimaryAction => 'Buscar en la tienda';
+
+  @override
+  String get homeChatAppNotFoundErrorSecondaryAction => 'Cancelar';
+
+  @override
+  String get recentNumbersTitle => 'Números recientes';
+
+  @override
+  String get recentNumbersEmpty => 'Aún no hay números recientes';
+
+  @override
+  String recentNumberRemoved(Object phoneNumber) {
+    return '¡El número reciente \"$phoneNumber\" fue eliminado!';
+  }
+
+  @override
+  String get actionRemove => 'Eliminar';
+
+  @override
+  String get actionUndo => 'Deshacer';
+
+  @override
+  String get actionSettings => 'Ajustes';
+
+  @override
+  String get callLogTabTitle => 'Llamadas';
+
+  @override
+  String get callLogPermissionMessage => 'Para acceder a tu historial de llamadas y facilitar la mensajería, necesitamos tu permiso. No te preocupes, no se almacena ni comparte ninguna información.';
+
+  @override
+  String get callLogPermissionButtonLabel => 'Conceder permiso';
+
+  @override
+  String get callLogEmptyMessage => 'No hay llamadas para mostrar';
+
+  @override
+  String get availableRegionsTitle => 'Selecciona un país';
+
+  @override
+  String get availableRegionsSearch => 'Buscar…';
+
+  @override
+  String get settingsTitle => 'Ajustes';
+
+  @override
+  String get settingsRegionTitle => 'Región predeterminada';
+
+  @override
+  String get settingsRegionSubtitle => 'Selecciona la región predeterminada para abrir un número';
+
+  @override
+  String get settingsMessagingAppsTitle => 'Aplicaciones de mensajería';
+
+  @override
+  String get settingsMessagingAppsSubtitle => 'Selecciona las aplicaciones de mensajería que deseas usar';
+
+  @override
+  String get messagingAppsTitle => 'Aplicaciones de mensajería';
+
+  @override
+  String get messagingAppsEnabledHeader => 'Aplicaciones disponibles';
+
+  @override
+  String get messagingAppsDisabledHeader => 'Aplicaciones ocultas';
+
+  @override
+  String get today => '\'Hoy a las\' H:mm';
+
+  @override
+  String get yesterday => '\'Ayer a las\' H:mm';
+
+  @override
+  String get lastCoupleOfDays => 'EEEE \'a las\' H:mm';
+
+  @override
+  String get lastCoupleOfMonths => 'd \'de\' MMMM \'a las\' H:mm';
+
+  @override
+  String get longTimeAgo => 'd \'de\' MMMM, yyyy';
+}

--- a/lib/common/resources/l10n/generated/app_localizations_pt.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_pt.dart
@@ -9,10 +9,10 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
-  String get unknowErrorMessage => 'Oops! Ocorreu um erro inesperado!';
+  String get unknownErrorMessage => 'Oops! Ocorreu um erro inesperado!';
 
   @override
-  String get unknowErrorAction => 'Tentar novamente';
+  String get unknownErrorAction => 'Tentar novamente';
 
   @override
   String get advertisementPlaceholder => 'Publicidade';

--- a/lib/common/resources/l10n/generated/app_localizations_pt.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_pt.dart
@@ -75,10 +75,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get callLogTabTitle => 'Chamadas';
 
   @override
-  String get callLogPermissionMessage => 'Para exibir o histórico de chamadas, é necessário permitir o acesso.';
+  String get callLogPermissionMessage => 'Para acessar seu histórico de chamadas e facilitar o envio de mensagens, precisamos da sua permissão. Saiba que nenhuma informação é armazenada ou compartilhada.';
 
   @override
-  String get callLogPermissionButtonLabel => 'Permitir';
+  String get callLogPermissionButtonLabel => 'Conceder permissão';
 
   @override
   String get callLogEmptyMessage => 'Nenhuma chamada para exibir';


### PR DESCRIPTION
This pull request includes several changes to improve the localization and error messaging in the application. The most important changes include fixing typos in error messages, updating permission request messages for better clarity, and adding new translations for Spanish.

Localization and error message improvements:

* [`lib/common/common_module.dart`](diffhunk://#diff-6490c63d4bd25d3e0ee696979da089811fbdd19f32962687e48a578756c090a1L25-R26): Corrected typos in error message keys from `unknowErrorMessage` to `unknownErrorMessage` and `unknowErrorAction` to `unknownErrorAction`.
* [`lib/common/resources/l10n/app_en.arb`](diffhunk://#diff-9dc8fb2b8e647dfd5a33767658c2ad1333941984f156347347026cd2c975d0f5L2-R3): Fixed typos in error messages and updated the call log permission message for better clarity. [[1]](diffhunk://#diff-9dc8fb2b8e647dfd5a33767658c2ad1333941984f156347347026cd2c975d0f5L2-R3) [[2]](diffhunk://#diff-9dc8fb2b8e647dfd5a33767658c2ad1333941984f156347347026cd2c975d0f5L28-R29)
* [`lib/common/resources/l10n/app_es.arb`](diffhunk://#diff-86ca04b11fff919ddfb0b5d67bbd4c301a919ae5798582e748a7d7548c89f666R1-R50): Added new translations for Spanish, including error messages, call log permissions, and various UI elements.
* [`lib/common/resources/l10n/app_pt.arb`](diffhunk://#diff-6c5daf94876bd1ba644b0dd374f9887a6d008e64e29be4044243de2ab49ecc01L2-R3): Corrected typos in error messages and updated the call log permission message for better clarity. [[1]](diffhunk://#diff-6c5daf94876bd1ba644b0dd374f9887a6d008e64e29be4044243de2ab49ecc01L2-R3) [[2]](diffhunk://#diff-6c5daf94876bd1ba644b0dd374f9887a6d008e64e29be4044243de2ab49ecc01L28-R29)