### PR TITLE
Fix Jekyll's build arguments

### DIFF
--- a/.github/workflows/jekyll-gh-pages-check.yml
+++ b/.github/workflows/jekyll-gh-pages-check.yml
@@ -39,10 +39,10 @@ jobs:
           working-directory: ./docs
 
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v5
 
       - name: Copy changelog to site root
-        id: pages
         run: cp CHANGELOG.md docs/changelog.md
 
       - name: Build with Jekyll

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -5,7 +5,10 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-    paths: ['docs/**', 'CHANGELOG.md']
+    paths:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/jekyll-*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -42,10 +45,10 @@ jobs:
           working-directory: ./docs
 
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v5
 
       - name: Copy changelog to site root
-        id: pages
         run: cp CHANGELOG.md docs/changelog.md
 
       - name: Build with Jekyll


### PR DESCRIPTION
This pull request makes updates to GitHub Actions workflows for Jekyll-based GitHub Pages. The changes include fixing an ID conflict in job steps and expanding the workflow trigger paths to include workflow files themselves.

### Workflow Improvements:

* [`.github/workflows/jekyll-gh-pages-check.yml`](diffhunk://#diff-13187e7d65e356daa20c6763c2922086b692eddf9cc77bf5f800763ecb355404R42-L45): Resolved an ID conflict in the `Setup Pages` and `Copy changelog to site root` steps by assigning a unique `id` (`pages`) to the `Setup Pages` step.

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L8-R11): Updated the workflow trigger paths under `on.push.paths` to include Jekyll-related workflow files (`.github/workflows/jekyll-*`) in addition to existing paths (`docs/**` and `CHANGELOG.md`).

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3R48-L48): Fixed an ID conflict in the `Setup Pages` and `Copy changelog to site root` steps by assigning a unique `id` (`pages`) to the `Setup Pages` step.