### PR TITLE
Fix chat app not found button text

### DIFF
--- a/lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dart
+++ b/lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dart
@@ -29,7 +29,7 @@ class ChatAppNotFoundDialog extends StatelessWidget {
             _openStore(app);
             Navigator.of(context).pop();
           },
-          child: Text(context.strings.homeChatAppNotFoundErrorSecondaryAction),
+          child: Text(context.strings.homeChatAppNotFoundErrorPrimaryAction),
         ),
       ],
     );


### PR DESCRIPTION
This pull request updates the text displayed on a button in the `ChatAppNotFoundDialog` widget to use the correct string resource for the primary action.

* **UI Text Update:**
  * Updated the button text in the `ChatAppNotFoundDialog` widget to use `homeChatAppNotFoundErrorPrimaryAction` instead of `homeChatAppNotFoundErrorSecondaryAction` for consistency with the intended primary action. (`lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dart`, [lib/features/home/chat_apps/presentation/dialogs/chat_app_not_found.dartL32-R32](diffhunk://#diff-fdd2979aa57ab2bd6280f9ebc2f5ec7c37615834e7d87bad2b12391d8daece6dL32-R32))