### PR TITLE
Normalize search term to lowercase for region filtering

### DIFF
--- a/lib/features/region/domain/usecase/get_regions_by_term.dart
+++ b/lib/features/region/domain/usecase/get_regions_by_term.dart
@@ -11,7 +11,7 @@ class GetRegionsByTermUseCase {
   final IRegionRepository _repository;
 
   Future<List<Country>> call({String term = ''}) async {
-    term = term.trim();
+    term = term.trim().toLowerCase();
     final countries = await _repository.getAll();
     if (term.isEmpty) {
       return countries;
@@ -19,9 +19,9 @@ class GetRegionsByTermUseCase {
 
     return countries
         .where((country) {
-          return country.code.toUpperCase().contains(term.toUpperCase()) ||
-              country.prefix.toString().contains(term) ||
-              country.name.toLowerCase().contains(term.toLowerCase());
+          final identifier = '${country.code.toLowerCase()} +${country.prefix}';
+          return identifier.contains(term) ||
+              country.name.toLowerCase().contains(term);
         })
         .toList(growable: false);
   }


### PR DESCRIPTION
This pull request refines the search functionality in the `GetRegionsByTermUseCase` class to improve accuracy and simplify the logic. The changes ensure that search terms and relevant fields are consistently compared in lowercase, and a new search identifier is introduced for better matching.

### Improvements to search functionality:

* [`lib/features/region/domain/usecase/get_regions_by_term.dart`](diffhunk://#diff-2b0942502426fe9834d6cc77a2feaaeeb0e7e198385353aeb031eeda48d8a450L14-R24): Updated the `term` parameter to be converted to lowercase after trimming, ensuring consistent case-insensitive comparisons.
* [`lib/features/region/domain/usecase/get_regions_by_term.dart`](diffhunk://#diff-2b0942502426fe9834d6cc77a2feaaeeb0e7e198385353aeb031eeda48d8a450L14-R24): Replaced the previous matching logic with a new `identifier` that combines the lowercase country code and prefix for more efficient and accurate term matching.