### PR TITLE
Add semantics for accessibility in history and phone field widgets

### DIFF
--- a/lib/features/history/presentation/history_page.dart
+++ b/lib/features/history/presentation/history_page.dart
@@ -136,21 +136,25 @@ class _SuccessView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      itemCount: entries.length,
-      itemBuilder: (_, index) {
-        final entry = entries.elementAt(index);
+    return Semantics(
+      identifier: 'HistoricList',
+      child: ListView.separated(
+        addSemanticIndexes: true,
+        itemCount: entries.length,
+        itemBuilder: (_, index) {
+          final entry = entries.elementAt(index);
 
-        if (isDismissible) {
-          return _DismissibleEntryView(entry);
-        }
+          if (isDismissible) {
+            return _DismissibleEntryView(entry);
+          }
 
-        return _EntryView(entry, key: ValueKey(entry.phoneNumber));
-      },
-      separatorBuilder: AdListViewSeparatorBuilder(
-        everyNthItem: adOptions?.interval ?? 0,
-        unitId: adOptions?.unitId ?? '',
-        defaultDivider: const ListDivider(),
+          return _EntryView(entry, key: ValueKey(entry.phoneNumber));
+        },
+        separatorBuilder: AdListViewSeparatorBuilder(
+          everyNthItem: adOptions?.interval ?? 0,
+          unitId: adOptions?.unitId ?? '',
+          defaultDivider: const ListDivider(),
+        ),
       ),
     );
   }

--- a/lib/features/home/phone/presentation/phone_field_widget.dart
+++ b/lib/features/home/phone/presentation/phone_field_widget.dart
@@ -25,31 +25,34 @@ class PhoneFieldWidget extends StatelessWidget
   Widget buildState(BuildContext context, PhoneFieldState state) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: TextField(
-        key: const ValueKey('PhoneNumber'),
-        style: _textFieldStyle,
-        focusNode: _textFieldFocus,
-        controller: state.controller,
-        textInputAction: TextInputAction.go,
-        keyboardType: TextInputType.phone,
-        // onSubmitted: widget.onSubmitted,
-        decoration: InputDecoration(
-          prefix: _RegionSelectorButton(
-            controller: state.controller,
-            region: state.region,
-            textFieldFocus: _textFieldFocus,
-            textStyle: _textFieldStyle,
+      child: Semantics(
+        identifier: 'PhoneNumberField',
+        child: TextField(
+          key: const ValueKey('PhoneNumber'),
+          style: _textFieldStyle,
+          focusNode: _textFieldFocus,
+          controller: state.controller,
+          textInputAction: TextInputAction.go,
+          keyboardType: TextInputType.phone,
+          // onSubmitted: widget.onSubmitted,
+          decoration: InputDecoration(
+            prefix: _RegionSelectorButton(
+              controller: state.controller,
+              region: state.region,
+              textFieldFocus: _textFieldFocus,
+              textStyle: _textFieldStyle,
+            ),
+            labelText: context.strings.homePhoneNumberLabel,
+            // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
+            // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
+            errorText:
+                _errorMessageAdapter.maybeAdapt(context, state.error)?.message,
+            contentPadding: const EdgeInsets.only(left: 8, right: 8),
+            border: const OutlineInputBorder(),
           ),
-          labelText: context.strings.homePhoneNumberLabel,
-          // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
-          // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
-          errorText:
-              _errorMessageAdapter.maybeAdapt(context, state.error)?.message,
-          contentPadding: const EdgeInsets.only(left: 8, right: 8),
-          border: const OutlineInputBorder(),
+          autocorrect: false,
+          enableSuggestions: false,
         ),
-        autocorrect: false,
-        enableSuggestions: false,
       ),
     );
   }
@@ -100,7 +103,10 @@ class _RegionSelectorButton extends StatelessWidget {
         }
         context.read<RegionMediator>().showRegionPicker(region.code);
       },
-      child: Text('${region.flag} +${region.prefix}', style: textStyle),
+      child: Semantics(
+        identifier: 'PhoneNumberRegionPicker',
+        child: Text('${region.flag} +${region.prefix}', style: textStyle),
+      ),
     );
   }
 }

--- a/lib/features/region/presentation/region_picker_page.dart
+++ b/lib/features/region/presentation/region_picker_page.dart
@@ -58,15 +58,21 @@ class _SearchViewState extends State<_SearchView> {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: ctrl,
-      decoration: InputDecoration(
-        contentPadding: const EdgeInsets.all(16),
-        hintText: context.strings.availableRegionsSearch,
-        border: const UnderlineInputBorder(),
-        suffixIcon: IconButton(
-          icon: const Icon(Icons.clear),
-          onPressed: ctrl.clear,
+    return Container(
+      color: Theme.of(context).colorScheme.surface,
+      child: Semantics(
+        identifier: 'RegionSearchField',
+        child: TextField(
+          controller: ctrl,
+          decoration: InputDecoration(
+            contentPadding: const EdgeInsets.all(16),
+            hintText: context.strings.availableRegionsSearch,
+            border: const UnderlineInputBorder(),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: ctrl.clear,
+            ),
+          ),
         ),
       ),
     );
@@ -133,22 +139,34 @@ class _RegionListTile extends StatelessWidget {
       onTap: () {
         onTap(region);
       },
-      title: Row(
-        children: [
-          ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 50),
-            child: Text(
-              region.flag ?? '',
-              style: const TextStyle(fontSize: 28),
-            ),
+      title: Semantics(
+        identifier: '${region.code} +${region.prefix}',
+        label: '${region.name} +${region.prefix}',
+        button: true,
+        child: ExcludeSemantics(
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 50),
+                child: Text(
+                  region.flag ?? '',
+                  style: const TextStyle(fontSize: 28),
+                ),
+              ),
+              Expanded(
+                child: Text(region.name, overflow: TextOverflow.ellipsis),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Text(
+                  '+${region.prefix}',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
           ),
-          Text('${region.name} (${region.code})'),
-          const Spacer(),
-          Text(
-            '+${region.prefix}',
-            style: const TextStyle(fontWeight: FontWeight.bold),
-          ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This pull request introduces semantic enhancements to improve accessibility across multiple widgets in the application. The changes primarily focus on adding `Semantics` widgets to provide meaningful identifiers, labels, and roles for screen readers, ensuring a better user experience for visually impaired users.

### Accessibility Improvements:

#### History Page:
* Wrapped the `ListView.separated` in `_SuccessView` with a `Semantics` widget, adding the identifier `HistoricList` and enabling semantic indexing for better accessibility. [[1]](diffhunk://#diff-04ba33f03ac98d2dfb7f191db21c846acd462ff89610a8269e0eda71004f3aa2L139-R142) [[2]](diffhunk://#diff-04ba33f03ac98d2dfb7f191db21c846acd462ff89610a8269e0eda71004f3aa2R158)

#### Phone Field Widgets:
* Added a `Semantics` widget around the `TextField` in `PhoneFieldWidget` with the identifier `PhoneNumberField` to provide a descriptive context for screen readers. [[1]](diffhunk://#diff-ebb982a02937254984b50aae89e527b58e3aee03389b8d376ca48f5bc8676684R28-R29) [[2]](diffhunk://#diff-ebb982a02937254984b50aae89e527b58e3aee03389b8d376ca48f5bc8676684R56)
* Enhanced the `_RegionSelectorButton` by wrapping its child in a `Semantics` widget with the identifier `PhoneNumberRegionPicker` for better region picker accessibility.

#### Region Picker Page:
* Improved the `_SearchView` by wrapping the `TextField` in a `Semantics` widget with the identifier `RegionSearchField` and a container with a background color for better visual and semantic clarity. [[1]](diffhunk://#diff-bbc5730769690c48a30b39076cd3fb22d94c00af4a5be18a40b5be4073d40de8L61-R65) [[2]](diffhunk://#diff-bbc5730769690c48a30b39076cd3fb22d94c00af4a5be18a40b5be4073d40de8R76-R77)
* Updated `_RegionListTile` to include a `Semantics` widget with a dynamic identifier and label for each region, marking the tile as a button and excluding redundant semantics from the child `Row`. Adjusted the `Text` widgets for better layout and overflow handling. [[1]](diffhunk://#diff-bbc5730769690c48a30b39076cd3fb22d94c00af4a5be18a40b5be4073d40de8L136-R148) [[2]](diffhunk://#diff-bbc5730769690c48a30b39076cd3fb22d94c00af4a5be18a40b5be4073d40de8L145-R170)