### PR TITLE
Enhance error handling for invalid phone numbers with detailed messages

### DIFF
--- a/lib/common/resources/l10n/app_en.arb
+++ b/lib/common/resources/l10n/app_en.arb
@@ -8,6 +8,7 @@
     "homeTopBannerAskToReviewButton": "REVIEW",
 
     "homePhoneNumberLabel": "Phone number",
+    "homeBrPhoneNumberLabel": "Phone number with area code",
     "homeOpenWithButton": "{appName}",
     "homeEmptyPhoneNumberError": "Please provide the phone number",
     "homeInvalidPhoneNumberError": "Invalid phone number",

--- a/lib/common/resources/l10n/app_es.arb
+++ b/lib/common/resources/l10n/app_es.arb
@@ -8,6 +8,7 @@
   "homeTopBannerAskToReviewButton": "OPINAR",
 
   "homePhoneNumberLabel": "Número de teléfono",
+  "homeBrPhoneNumberLabel": "Número de teléfono con DDD",
   "homeOpenWithButton": "{appName}",
   "homeEmptyPhoneNumberError": "Por favor, introduce el número de teléfono",
   "homeInvalidPhoneNumberError": "Número de teléfono no válido",

--- a/lib/common/resources/l10n/app_pt.arb
+++ b/lib/common/resources/l10n/app_pt.arb
@@ -8,6 +8,7 @@
     "homeTopBannerAskToReviewButton": "AVALIAR",
 
     "homePhoneNumberLabel": "Número de telefone",
+    "homeBrPhoneNumberLabel": "Número de telefone com DDD",
     "homeOpenWithButton": "{appName}",
     "homeEmptyPhoneNumberError": "Por favor informe o número desejado.",
     "homeInvalidPhoneNumberError": "O número informado é inválido",

--- a/lib/common/resources/l10n/generated/app_localizations.dart
+++ b/lib/common/resources/l10n/generated/app_localizations.dart
@@ -133,6 +133,12 @@ abstract class AppLocalizations {
   /// **'Phone number'**
   String get homePhoneNumberLabel;
 
+  /// No description provided for @homeBrPhoneNumberLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Phone number with area code'**
+  String get homeBrPhoneNumberLabel;
+
   /// No description provided for @homeOpenWithButton.
   ///
   /// In en, this message translates to:

--- a/lib/common/resources/l10n/generated/app_localizations_en.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_en.dart
@@ -27,6 +27,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homePhoneNumberLabel => 'Phone number';
 
   @override
+  String get homeBrPhoneNumberLabel => 'Phone number with area code';
+
+  @override
   String homeOpenWithButton(Object appName) {
     return '$appName';
   }

--- a/lib/common/resources/l10n/generated/app_localizations_es.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_es.dart
@@ -27,6 +27,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homePhoneNumberLabel => 'Número de teléfono';
 
   @override
+  String get homeBrPhoneNumberLabel => 'Número de teléfono con DDD';
+
+  @override
   String homeOpenWithButton(Object appName) {
     return '$appName';
   }

--- a/lib/common/resources/l10n/generated/app_localizations_pt.dart
+++ b/lib/common/resources/l10n/generated/app_localizations_pt.dart
@@ -27,6 +27,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get homePhoneNumberLabel => 'Número de telefone';
 
   @override
+  String get homeBrPhoneNumberLabel => 'Número de telefone com DDD';
+
+  @override
   String homeOpenWithButton(Object appName) {
     return '$appName';
   }

--- a/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
@@ -31,11 +31,11 @@ class ChatAppsBloc extends StateActionBloc<ChatAppsState, ChatAppsAction> {
     sendAction(ChatAppsAction.select(entry));
   }
 
-  void selectFailed(ChatApp entry, Object error) {
+  void selectFailed(ChatApp entry, Object error, StackTrace? stackTrace) {
     if (error is ChatAppNotFoundError) {
       sendAction(ChatAppsAction.showFailureMessage(entry));
     } else {
-      Log.e(error);
+      Log.e(error, stackTrace);
     }
   }
 

--- a/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
@@ -38,7 +38,9 @@ class ChatAppsWidget extends StatelessWidget
     final chatAppsMediator = context.read<ChatAppsMediator>();
     await chatAppsMediator
         .launch(entry.deeplinkTemplate)
-        .catchError((err, stack) => chatAppsBloc.selectFailed(entry, err));
+        .catchError(
+          (err, stack) => chatAppsBloc.selectFailed(entry, err, stack),
+        );
   }
 
   Future<void> _showChatFailureMessage(

--- a/lib/features/home/phone/domain/phone_field_error.dart
+++ b/lib/features/home/phone/domain/phone_field_error.dart
@@ -2,4 +2,13 @@ import '../../../../../common/domain/error.dart';
 
 class EmptyPhoneNumberError extends NonReportableError {}
 
-class InvalidPhoneNumberError extends NonReportableError {}
+class InvalidPhoneNumberError extends Error {
+  InvalidPhoneNumberError([this.message]);
+
+  final String? message;
+
+  @override
+  String toString() {
+    return 'InvalidPhoneNumberError{message: $message}';
+  }
+}

--- a/lib/features/home/phone/presentation/phone_field_bloc.dart
+++ b/lib/features/home/phone/presentation/phone_field_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logify/logify.dart';
@@ -124,7 +126,10 @@ class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction>
     ) {
       // prevent phone number on error logging
       if (error is PlatformException && error.code == 'InvalidNumber') {
-        error = InvalidPhoneNumberError();
+        error = InvalidPhoneNumberError(
+          'Invalid phone number with initial numbers: '
+          '${phone.substring(0, math.min(3, phone.length))}',
+        );
       }
       Error.throwWithStackTrace(error, stackTrace);
     });

--- a/lib/features/home/phone/presentation/phone_field_widget.dart
+++ b/lib/features/home/phone/presentation/phone_field_widget.dart
@@ -42,7 +42,10 @@ class PhoneFieldWidget extends StatelessWidget
               textFieldFocus: _textFieldFocus,
               textStyle: _textFieldStyle,
             ),
-            labelText: context.strings.homePhoneNumberLabel,
+            labelText:
+                state.region?.code != 'BR'
+                    ? context.strings.homePhoneNumberLabel
+                    : context.strings.homeBrPhoneNumberLabel,
             // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
             // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
             errorText:


### PR DESCRIPTION
This pull request introduces localization updates, error-handling improvements, and region-specific UI adjustments. Key changes include adding a new localized string for Brazilian phone numbers, enhancing error logging with more context, and updating the UI label dynamically based on the user's region.

### Localization Updates:
* Added a new localized string `homeBrPhoneNumberLabel` for Brazilian phone numbers in `app_en.arb`, `app_es.arb`, and `app_pt.arb` files. [[1]](diffhunk://#diff-9dc8fb2b8e647dfd5a33767658c2ad1333941984f156347347026cd2c975d0f5R11) [[2]](diffhunk://#diff-86ca04b11fff919ddfb0b5d67bbd4c301a919ae5798582e748a7d7548c89f666R11) [[3]](diffhunk://#diff-6c5daf94876bd1ba644b0dd374f9887a6d008e64e29be4044243de2ab49ecc01R11)

### Error Handling Improvements:
* Updated the `InvalidPhoneNumberError` class to accept an optional error message and override the `toString` method for better error context.
* Enhanced error logging in `PhoneFieldBloc` by including the first few digits of the invalid phone number in the error message.
* Modified the `selectFailed` method in `ChatAppsBloc` to accept an optional `StackTrace` and updated related call sites to pass the stack trace for improved debugging. [[1]](diffhunk://#diff-39d49af0ba10e3509fea6d86afcdf77ca775bb76c44f2d0f1e310af3a997dcf7L34-R38) [[2]](diffhunk://#diff-00bd10928108f7ae488ed0ab48a581ad0ca9171cf0c56daf4dcefc2e5917253dL41-R43)

### UI Adjustments:
* Updated the phone number label in `PhoneFieldWidget` to display `homeBrPhoneNumberLabel` for users in Brazil, based on the region code.

### Miscellaneous:
* Added an import for `dart:math` in `PhoneFieldBloc`, likely to support the new error message logic.