### PR TITLE
Add errorDisplayed method and analytics logging for error events

### DIFF
--- a/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_bloc.dart
@@ -37,6 +37,10 @@ class ChatAppsBloc extends StateActionBloc<ChatAppsState, ChatAppsAction> {
     } else {
       Log.e(error, stackTrace);
     }
+    _analytics.errorDisplayed(
+      'launch_chat_app',
+      properties: {'app_launched': entry.name, 'error': error.toString()},
+    );
   }
 
   ChatAppsState _mapToState(Iterable<ChatApp> entries) =>

--- a/packages/analytics/lib/src/composite.dart
+++ b/packages/analytics/lib/src/composite.dart
@@ -71,6 +71,15 @@ class Analytics implements IAnalytics {
   );
 
   @override
+  void errorDisplayed(
+    String name, {
+    Map<String, Object> properties = const {},
+  }) => logEvent(
+    'error_displayed',
+    properties: {'error_name': name, ...properties},
+  );
+
+  @override
   void logEvent(
     String name, {
     Map<String, Object> properties = const {},

--- a/packages/analytics/lib/src/wrapper.dart
+++ b/packages/analytics/lib/src/wrapper.dart
@@ -37,5 +37,7 @@ abstract class IAnalytics {
 
   void intentHandled(String name, {Map<String, Object> properties = const {}});
 
+  void errorDisplayed(String name, {Map<String, Object> properties = const {}});
+
   void logEvent(String name, {Map<String, Object> properties = const {}});
 }


### PR DESCRIPTION
This pull request introduces a new analytics feature to log errors when they are displayed in the chat apps module. The changes include adding a new method, `errorDisplayed`, to the analytics interface and its implementation, as well as integrating this method into the chat apps business logic.

### Analytics Enhancements:
* [`packages/analytics/lib/src/wrapper.dart`](diffhunk://#diff-c8bb72ae524197d779d69eae9f5cc3b5916b88de9df12da0992fea30ba1abeb2R40-R41): Added a new `errorDisplayed` method to the `IAnalytics` interface to enable logging of displayed errors.
* [`packages/analytics/lib/src/composite.dart`](diffhunk://#diff-5d5d087a2de98877a63ae4d2bf14dd40650de8c115ddc29a268a3fccbd927133R73-R81): Implemented the `errorDisplayed` method in the `Analytics` class to log events with the name `error_displayed` and include error details in the properties.

### Chat Apps Integration:
* [`lib/features/home/chat_apps/presentation/chat_apps_bloc.dart`](diffhunk://#diff-39d49af0ba10e3509fea6d86afcdf77ca775bb76c44f2d0f1e310af3a997dcf7R40-R43): Integrated the `errorDisplayed` method into the `ChatAppsBloc` to log errors when a chat app fails to launch, including the app name and error details in the analytics event.