### PR TITLE
Update request review logic

### DIFF
--- a/lib/common/config/remote_config.dart
+++ b/lib/common/config/remote_config.dart
@@ -11,7 +11,8 @@ enum RemoteConfig with KeyValueMixin<IRemoteConfigStorage> {
   homeAdListUnitId,
   homeAdListInterval,
   isCallLogTabEnabled,
-  isRequestReviewEnabled;
+  isRequestReviewEnabled,
+  askForReviewDaysInterval;
 
   @override
   String get key => name;
@@ -25,5 +26,6 @@ Map<String, dynamic> get remoteConfigDefaults => {
   RemoteConfig.homeAdListUnitId.key: EnvConfig.homeAdListUnitId,
   RemoteConfig.homeAdListInterval.key: 4,
   RemoteConfig.isCallLogTabEnabled.key: kDebugMode && Platform.isAndroid,
-  RemoteConfig.isRequestReviewEnabled.key: kDebugMode,
+  RemoteConfig.isRequestReviewEnabled.key: false,
+  RemoteConfig.askForReviewDaysInterval.key: 30,
 };

--- a/lib/features/home/chat_apps/chat_apps_module.dart
+++ b/lib/features/home/chat_apps/chat_apps_module.dart
@@ -3,6 +3,10 @@ import 'presentation/chat_apps_bloc.dart';
 
 void chatAppsModule() {
   registerFactory(
-    () => ChatAppsBloc(getEnabledChatApps: get(), analytics: get()),
+    () => ChatAppsBloc(
+      getEnabledChatApps: get(),
+      maybeRequestAppReviewUseCase: get(),
+      analytics: get(),
+    ),
   );
 }

--- a/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
+++ b/lib/features/home/chat_apps/presentation/chat_apps_widget.dart
@@ -38,9 +38,12 @@ class ChatAppsWidget extends StatelessWidget
     final chatAppsMediator = context.read<ChatAppsMediator>();
     await chatAppsMediator
         .launch(entry.deeplinkTemplate)
-        .catchError(
-          (err, stack) => chatAppsBloc.selectFailed(entry, err, stack),
-        );
+        .then((_) {
+          chatAppsBloc.chatOpenedSuccessful();
+        })
+        .catchError((err, stack) {
+          chatAppsBloc.selectFailed(entry, err, stack);
+        });
   }
 
   Future<void> _showChatFailureMessage(

--- a/lib/features/home/top_banner/domain/usecase/app_review.dart
+++ b/lib/features/home/top_banner/domain/usecase/app_review.dart
@@ -17,7 +17,13 @@ class CanAskForReviewUseCase {
         .get<int?>()
         .thenIfNotNull(DateTime.fromMillisecondsSinceEpoch)
         .orDefault(() => AppInstallDate().installDate)
-        .then((date) => date.add(const Duration(days: 31)));
+        .then(
+          (date) async => date.add(
+            Duration(
+              days: await RemoteConfig.askForReviewDaysInterval.get<int>(),
+            ),
+          ),
+        );
 
     return DateTime.now().isAfter(nextReviewAt);
   }

--- a/lib/features/home/top_banner/domain/usecase/app_review.dart
+++ b/lib/features/home/top_banner/domain/usecase/app_review.dart
@@ -1,4 +1,5 @@
 import 'package:app_install_date/app_install_date.dart';
+import 'package:logify/logify.dart';
 
 import '../../../../../../common/config/local_config.dart';
 import '../../../../../../common/config/remote_config.dart';
@@ -31,7 +32,11 @@ class CanAskForReviewUseCase {
 
 class SetLastAppReviewAtNowUseCase {
   void call() async {
-    final now = DateTime.now().millisecondsSinceEpoch;
-    await LocalConfig.lastAppReviewAt.set(now);
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await LocalConfig.lastAppReviewAt.set(now);
+    } catch (e, stackTrace) {
+      Log.e(e, stackTrace);
+    }
   }
 }

--- a/lib/features/home/top_banner/domain/usecase/get_top_banner.dart
+++ b/lib/features/home/top_banner/domain/usecase/get_top_banner.dart
@@ -4,11 +4,9 @@ import 'app_review.dart';
 class GetTopBannerUseCase {
   GetTopBannerUseCase({required this.canAskForReview});
 
-  CanAskForReviewUseCase canAskForReview;
+  final CanAskForReviewUseCase canAskForReview;
 
   Stream<TopBannerType> call() async* {
-    if (await canAskForReview()) {
-      yield TopBannerType.appReview;
-    }
+    // TODO: Implement logic to determine the top banner type
   }
 }

--- a/lib/features/home/top_banner/domain/usecase/maybe_request_app_review.dart
+++ b/lib/features/home/top_banner/domain/usecase/maybe_request_app_review.dart
@@ -1,0 +1,36 @@
+import 'package:in_app_review/in_app_review.dart';
+import 'package:logify/logify.dart';
+
+import 'app_review.dart';
+
+class MaybeRequestAppReviewUseCase {
+  MaybeRequestAppReviewUseCase({
+    required CanAskForReviewUseCase canAskForReview,
+    required SetLastAppReviewAtNowUseCase setLastAppReviewAtNow,
+  }) : _canAskForReview = canAskForReview,
+       _setLastAppReviewAtNow = setLastAppReviewAtNow;
+
+  final CanAskForReviewUseCase _canAskForReview;
+  final SetLastAppReviewAtNowUseCase _setLastAppReviewAtNow;
+
+  Future<bool> call() async {
+    try {
+      if (!await _canAskForReview()) return false;
+
+      final inAppReview = InAppReview.instance;
+      final isInAppReviewAvailable = await inAppReview.isAvailable();
+
+      if (!isInAppReviewAvailable) {
+        throw Exception('InAppReview not available');
+      }
+
+      await inAppReview.requestReview();
+      return true;
+    } catch (e, stackTrace) {
+      Log.e('Error requesting app review: $e', e, stackTrace);
+      return false;
+    } finally {
+      _setLastAppReviewAtNow();
+    }
+  }
+}

--- a/lib/features/home/top_banner/top_banner_module.dart
+++ b/lib/features/home/top_banner/top_banner_module.dart
@@ -1,6 +1,7 @@
 import '../../../../common/di/definition.dart';
 import 'domain/usecase/app_review.dart';
 import 'domain/usecase/get_top_banner.dart';
+import 'domain/usecase/maybe_request_app_review.dart';
 import 'presentation/top_banner_bloc.dart';
 
 void topBannerModule() {
@@ -15,6 +16,13 @@ void topBannerModule() {
   registerFactory(() => GetTopBannerUseCase(canAskForReview: get()));
 
   registerFactory(() => CanAskForReviewUseCase());
+
+  registerFactory(
+    () => MaybeRequestAppReviewUseCase(
+      setLastAppReviewAtNow: get(),
+      canAskForReview: get(),
+    ),
+  );
 
   registerFactory(() => SetLastAppReviewAtNowUseCase());
 }


### PR DESCRIPTION
This pull request introduces a new feature to request in-app reviews from users, along with associated changes to integrate, configure, and handle this functionality. The most important changes include adding a new use case for requesting reviews, updating configuration settings, and modifying existing classes to incorporate the review request logic.

### New Feature: In-App Review Request

* **Added `MaybeRequestAppReviewUseCase`**: Implements the logic to determine if an in-app review can be requested and triggers the review request using the `InAppReview` package. Handles errors and logs them if the review cannot be requested. (`lib/features/home/top_banner/domain/usecase/maybe_request_app_review.dart`)

### Configuration Updates

* **Updated `RemoteConfig`**: Added a new key, `askForReviewDaysInterval`, to configure the interval (in days) for asking for reviews. Updated the default value to 30 days. (`lib/common/config/remote_config.dart`) [[1]](diffhunk://#diff-2a0422d64574cdb79ab6f49c4cce90df11729e5626237a9362aaf91f0aeb0fe5L14-R15) [[2]](diffhunk://#diff-2a0422d64574cdb79ab6f49c4cce90df11729e5626237a9362aaf91f0aeb0fe5L28-R30)

### Integration with Existing Features

* **Modified `ChatAppsBloc`**: Added the `MaybeRequestAppReviewUseCase` dependency to handle review requests after a successful chat app launch. Logs analytics events for both successful launches and review requests. (`lib/features/home/chat_apps/presentation/chat_apps_bloc.dart`) [[1]](diffhunk://#diff-39d49af0ba10e3509fea6d86afcdf77ca775bb76c44f2d0f1e310af3a997dcf7R8-R27) [[2]](diffhunk://#diff-39d49af0ba10e3509fea6d86afcdf77ca775bb76c44f2d0f1e310af3a997dcf7L46-R56)
* **Updated `ChatAppsWidget`**: Integrated `chatOpenedSuccessful` to trigger the review request logic after launching a chat app. (`lib/features/home/chat_apps/presentation/chat_apps_widget.dart`)

### Dependency Injection

* **Registered New Dependencies**: Added `MaybeRequestAppReviewUseCase` to the dependency injection system in the `topBannerModule`. (`lib/features/home/top_banner/top_banner_module.dart`) [[1]](diffhunk://#diff-33cee1f590ebbfd394281d95c77a72706ef99fbf0c33c79379075101a3026166R4) [[2]](diffhunk://#diff-33cee1f590ebbfd394281d95c77a72706ef99fbf0c33c79379075101a3026166R20-R26)

### Additional Enhancements

* **Improved Error Handling**: Added logging for errors in `SetLastAppReviewAtNowUseCase` to ensure issues during review timestamp updates are captured. (`lib/features/home/top_banner/domain/usecase/app_review.dart`)