### PR TITLE
fix(ui): Keyboard visibility

### DIFF
--- a/lib/features/home/main/home_page.dart
+++ b/lib/features/home/main/home_page.dart
@@ -146,6 +146,8 @@ class _HomePageState extends State<_HomePage>
 
     if (selectedRegion is IRegion) {
       await _bloc?.onRegionSelected(selectedRegion);
+    } else if (context.mounted) {
+      context.read<PhoneFieldComponent>().requestFieldFocus();
     }
   }
 

--- a/lib/features/home/phone/phone_field_component.dart
+++ b/lib/features/home/phone/phone_field_component.dart
@@ -9,6 +9,8 @@ abstract class PhoneFieldComponent {
 
   Future<void> updateRegion(IRegion region);
 
+  void requestFieldFocus();
+
   void unfocusField();
 
   void clearField();

--- a/lib/features/home/phone/presentation/phone_field_bloc.dart
+++ b/lib/features/home/phone/presentation/phone_field_bloc.dart
@@ -74,6 +74,11 @@ class PhoneFieldBloc extends StateActionBloc<PhoneFieldState, PhoneFieldAction>
   }
 
   @override
+  void requestFieldFocus() {
+    sendAction(PhoneFieldAction.showKeyboard());
+  }
+
+  @override
   void unfocusField() {
     sendAction(PhoneFieldAction.hideKeyboard());
   }

--- a/lib/features/home/phone/presentation/phone_field_widget.dart
+++ b/lib/features/home/phone/presentation/phone_field_widget.dart
@@ -1,6 +1,7 @@
 import 'package:error_adapter/error_adapter.dart';
 import 'package:flutter/material.dart';
 import 'package:state_action_bloc/state_action_bloc.dart';
+import 'package:ui/widgets.dart';
 
 import '../../../../../common/di/inject.dart';
 import '../../../../../common/ext/context.dart';
@@ -25,36 +26,44 @@ class PhoneFieldWidget extends StatelessWidget
   Widget buildState(BuildContext context, PhoneFieldState state) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Semantics(
-        identifier: 'PhoneNumberField',
-        child: TextField(
-          key: const ValueKey('PhoneNumber'),
-          style: _textFieldStyle,
-          focusNode: _textFieldFocus,
-          controller: state.controller,
-          textInputAction: TextInputAction.go,
-          keyboardType: TextInputType.phone,
-          // onSubmitted: widget.onSubmitted,
-          decoration: InputDecoration(
-            prefix: _RegionSelectorButton(
-              controller: state.controller,
-              region: state.region,
-              textFieldFocus: _textFieldFocus,
-              textStyle: _textFieldStyle,
+      child: KeyboardVisibilityBuilder(
+        builder: (_, child, isVisible) {
+          if (!isVisible) _textFieldFocus.unfocus();
+          return child!;
+        },
+        child: Semantics(
+          identifier: 'PhoneNumberField',
+          child: TextField(
+            key: const ValueKey('PhoneNumber'),
+            style: _textFieldStyle,
+            focusNode: _textFieldFocus,
+            controller: state.controller,
+            textInputAction: TextInputAction.go,
+            keyboardType: TextInputType.phone,
+            autocorrect: false,
+            enableSuggestions: false,
+            // onSubmitted: widget.onSubmitted,
+            decoration: InputDecoration(
+              prefix: _RegionSelectorButton(
+                controller: state.controller,
+                region: state.region,
+                textFieldFocus: _textFieldFocus,
+                textStyle: _textFieldStyle,
+              ),
+              labelText:
+                  state.region?.code != 'BR'
+                      ? context.strings.homePhoneNumberLabel
+                      : context.strings.homeBrPhoneNumberLabel,
+              // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
+              // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
+              errorText:
+                  _errorMessageAdapter
+                      .maybeAdapt(context, state.error)
+                      ?.message,
+              contentPadding: const EdgeInsets.only(left: 8, right: 8),
+              border: const OutlineInputBorder(),
             ),
-            labelText:
-                state.region?.code != 'BR'
-                    ? context.strings.homePhoneNumberLabel
-                    : context.strings.homeBrPhoneNumberLabel,
-            // https://github.com/flutter/flutter/issues/15400#issuecomment-475773473
-            // helperText: ' ', // FIXME: talkback says "Space", should be avoided to fix it
-            errorText:
-                _errorMessageAdapter.maybeAdapt(context, state.error)?.message,
-            contentPadding: const EdgeInsets.only(left: 8, right: 8),
-            border: const OutlineInputBorder(),
           ),
-          autocorrect: false,
-          enableSuggestions: false,
         ),
       ),
     );

--- a/packages/commons/ui/lib/src/widgets/keyboard_visibility.dart
+++ b/packages/commons/ui/lib/src/widgets/keyboard_visibility.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+
+typedef OnKeyboardVisibilityBuilder =
+    Widget Function(
+      BuildContext context,
+      Widget? child,
+      bool isKeyboardVisible,
+    );
+
+// Calls `builder` on keyboard close/open.
+/// https://stackoverflow.com/a/63241409/1321917
+class KeyboardVisibilityBuilder extends StatefulWidget {
+  const KeyboardVisibilityBuilder({
+    super.key,
+    this.child,
+    required this.builder,
+  });
+
+  final Widget? child;
+
+  final OnKeyboardVisibilityBuilder builder;
+
+  @override
+  State<KeyboardVisibilityBuilder> createState() =>
+      _KeyboardVisibilityBuilderState();
+}
+
+class _KeyboardVisibilityBuilderState extends State<KeyboardVisibilityBuilder>
+    with WidgetsBindingObserver {
+  bool _isKeyboardVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    final bottomInset = View.of(context).viewInsets.bottom;
+    final newValue = bottomInset > 0.0;
+    if (newValue != _isKeyboardVisible) {
+      setState(() {
+        _isKeyboardVisible = newValue;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      widget.builder(context, widget.child, _isKeyboardVisible);
+}

--- a/packages/commons/ui/lib/widgets.dart
+++ b/packages/commons/ui/lib/widgets.dart
@@ -2,3 +2,4 @@ library;
 
 export 'src/widgets/bottom_sheet_scaffold.dart';
 export 'src/widgets/image_resolver_widget.dart';
+export 'src/widgets/keyboard_visibility.dart';


### PR DESCRIPTION
Currently when phone field has focus but keyboard is not showing, this PR adjusts this behavior, opening the keyboard if the field has focus and loses focus if the keyboard was closed.